### PR TITLE
JCN-108-configuracion-de-protocolo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Protocol field in config
+- `userPrefix` getter
 
 ## [1.1.0] - 2019-07-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Protocol field in config
 
+## [1.1.0] - 2019-07-05
 ### Added
 - MongoDB wrapper
 - Tests
@@ -29,3 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `getFilter()` now only get filters from the unique indexes of the model
 - `get()`, `update()` and `multiRemove()` can use any items in the filters
 - host field in config not need mongodb protocol anymore
+
+## [1.0.0] - 2019-05-17
+### Added
+- Initial version

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Constructs the MongoDB driver instance, connected with the `config [Object]`.
 Config usage:
 ```js
 {
-   host: 'localhost', // "mongodb://" not needed
+   protocol: 'mongodb://', // Default "mongodb://"
+   host: 'localhost', // Default "localhost"
    port: 27017, // Default 27017
    limit: 500, // Default 500
    user: 'fizzmod',
@@ -126,7 +127,8 @@ const MongoDB = require('@janiscommerce/mongodb');
 const Model = require('myModel');
 
 const mongo = new MongoDB({
-   host: 'localhost', // mongodb:// not needed
+   protocol: 'mongodb://',
+   host: 'localhost', 
    port: 27017
    user: 'fizzmod',
    password: 'sarasa',

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -10,7 +10,9 @@ const MongoDBError = require('./mongodb-error');
 
 const DEFAULT_LIMIT = 500;
 
-const MONGODB_URL_PREFIX = 'mongodb://';
+const MONGODB_DEFAULT_PROTOCOL = 'mongodb://';
+
+const MONGODB_DEFAULT_HOST = 'localhost';
 
 /**
  * @class MongoDB
@@ -23,13 +25,16 @@ class MongoDB {
 			throw new MongoDBError('Invalid config', MongoDBError.codes.INVALID_CONFIG);
 
 		this.config = {
-			host: config.host ? config.host.replace(MONGODB_URL_PREFIX, '') : '',
+			protocol: config.protocol || MONGODB_DEFAULT_PROTOCOL,
+			host: config.host || MONGODB_DEFAULT_HOST,
 			port: config.port || 27017,
 			user: config.user || '',
 			password: config.password || '',
 			database: config.database || '',
 			limit: config.limit || DEFAULT_LIMIT
 		};
+		// Avoid protocol duplication
+		this.config.host = this.config.host.replace(this.config.protocol, '');
 	}
 
 	/**
@@ -42,7 +47,7 @@ class MongoDB {
 
 				this.client = await MongoClient.connect(
 
-					`${MONGODB_URL_PREFIX}${this.config.user ?
+					`${this.config.protocol}${this.config.user ?
 						`${this.config.user}:${this.config.password}@` : ''}${this.config.host}:${this.config.port}/${this.config.database}`,
 					{
 						useNewUrlParser: true

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -38,6 +38,14 @@ class MongoDB {
 	}
 
 	/**
+	 * MongoDB connection URL user prefix
+	 * @returns {String} MongoDB URL user prefix
+	 */
+	get userPrefix() {
+		return this.config && this.config.user ? `${this.config.user}:${this.config.password}@` : '';
+	}
+
+	/**
 	 * Checks the connection to the database
 	 * @throws if the connection is not successfull
 	 */
@@ -47,8 +55,7 @@ class MongoDB {
 
 				this.client = await MongoClient.connect(
 
-					`${this.config.protocol}${this.config.user ?
-						`${this.config.user}:${this.config.password}@` : ''}${this.config.host}:${this.config.port}/${this.config.database}`,
+					`${this.config.protocol}${this.userPrefix}${this.config.host}:${this.config.port}/${this.config.database}`,
 					{
 						useNewUrlParser: true
 					});


### PR DESCRIPTION
**CONFIGURACIÓN DE PROTOCOLO**
JCN-108 configuracion de protocolo

**LINK AL TICKET**
[https://fizzmod.atlassian.net/browse/JCN-108](url)

**DESCRIPCIÓN DEL REQUERIMIENTO**
1.1. Se debe poder modificar por configuración si el protocolo al utilizar (definido como MONGODB_URL_PREFIX). Actualmente es siempre es mongodb://, pero Atlas necesita que sea mongodb+srv://1.2. Debe ser configurable por cada dbKey

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se aplicaron los cambios solicitados.