### PR TITLE
JCN 140 mongodb debe retornar id al insertar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+## Chanded
+- `insert` returns ID of the object inserted
+- `multiInsert` returns an `array` with ID of the objects inserted
+
 ## [1.3.0] - 2019-07-30
 ### Added
 - Order parameter for `get()` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-## Chanded
+## Changed
 - `insert` returns ID of the object inserted
 - `multiInsert` returns an `array` with ID of the objects inserted
 - `save` returns ID of the object if it was inserted, or the Unique Index used as filter if it was updated
+- `multiSave` returns an `array` with ID of the objects inserted/updated
 
 ## [1.3.0] - 2019-07-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ## Changed
 - `insert` returns ID of the object inserted
-- `save` returns ID of the object if it was inserted / updated
+- `save` returns ID of the object if it was inserted / Unique Index used as filter if it was updated
 
 ## [1.3.2] - 2019-08-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Chanded
 - `insert` returns ID of the object inserted
 - `multiInsert` returns an `array` with ID of the objects inserted
+- `save` returns ID of the object if it was inserted, or the Unique Index used as filter if it was updated
 
 ## [1.3.0] - 2019-07-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ getTotals return example:
 - ***async*** `save(model, {item})`
 Insert/update a item into the database.
 Requires a `model [Model]` and `item [Object]`.
-Returns `ID` if element was inserted or Unique Index used as filter if it was updated.
+Returns `ID` if element was inserted/updated.
 
 - ***async*** `multiSave(model, [{items}], limit)`
 Insert/update multiple items into the database.
 Requires a `model [Model]` and `items [Object array]`.
 `limit [Number]` (optional, default 1000): Specifies the max amount of items that can be written at same time.
-Returns `true/false` if the result was successfully or not.
+Returns `[Array]` with the `id` of the objects inserted/updated.
 
 - ***async*** `remove(model, {item})`
 Removes the specified item from the database.
@@ -195,7 +195,7 @@ mongo.createIndexes(model);
       { id: 1, value: 'sarasa 1' },
       { id: 2, value: 'sarasa 2' },
       { id: 3, value: 'sarasa 3' }
-   ]); // expected return: true
+   ]); // expected return: ['00000058faf66849077316ba', '00000059faf66849077316bb', '0000005afaf66849077316bc']
 
    // remove
    result = await mongo.remove(model, { id: '0000000055f2255a1a8e0c54' }); // expected return: true

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ getTotals return example:
 - ***async*** `save(model, {item})`
 Insert/update a item into the database.
 Requires a `model [Model]` and `item [Object]`.
-Returns `String` *ID* of the item inserted / updated or rejects if cannot.
+Returns `String` **ID** of the item *inserted* or **Unique Index** used as filter if it was *updated* or rejects if cannot.
 
 - ***async*** `multiSave(model, [{items}], limit)`
 Insert/update multiple items into the database.

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Requires a `model [Model]`
 - ***async*** `insert(model, {item})`
 Insert a item into the database.
 Requires a `model [Model]` and `item [Object]`.
-Returns `id` of the item inserted or rejects if cannot.
+Returns `String` *ID* of the item inserted or rejects if cannot.
 
 - ***async*** `multiInsert(model, [{items}])`
 Inserts multiple items into the database.
 Requires a `model [Model]` and `item [Object array]`.
-Returns `[Array]` with the `id` of the objects inserted.
+Returns `true` if the operation was successfull or `false` if not.
 
 - ***async*** `update(model, {values}, {filter})`
 Updates one or multiple items from the database.
@@ -91,13 +91,13 @@ getTotals return example:
 - ***async*** `save(model, {item})`
 Insert/update a item into the database.
 Requires a `model [Model]` and `item [Object]`.
-Returns `ID` if element was inserted/updated.
+Returns `String` *ID* of the item inserted / updated or rejects if cannot.
 
 - ***async*** `multiSave(model, [{items}], limit)`
 Insert/update multiple items into the database.
 Requires a `model [Model]` and `items [Object array]`.
 `limit [Number]` (optional, default 1000): Specifies the max amount of items that can be written at same time.
-Returns `[Array]` with the `id` of the objects inserted/updated.
+Returns `true/false` if the result was successfully or not.
 
 - ***async*** `remove(model, {item})`
 Removes the specified item from the database.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ getTotals return example:
 - ***async*** `save(model, {item})`
 Insert/update a item into the database.
 Requires a `model [Model]` and `item [Object]`.
-Returns `true/false` if the result was successfully or not.
+Returns `ID` if element was inserted or Unique Index used as filter if it was updated.
 
 - ***async*** `multiSave(model, [{items}], limit)`
 Insert/update multiple items into the database.
@@ -188,7 +188,7 @@ mongo.createIndexes(model);
    result = await mongo.save(model, {
       id: 1,
       value: 'sarasa'
-   }); // expected return: true
+   }); // expected return: '00000058faf66849077316ba'
 
    // multiSave
    result = await mongo.multiSave(model, [

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Requires a `model [Model]`
 - ***async*** `insert(model, {item})`
 Insert a item into the database.
 Requires a `model [Model]` and `item [Object]`.
-Returns `true` if the operation was successfull or `false` if not.
+Returns `id` of the item inserted or rejects if cannot.
 
 - ***async*** `multiInsert(model, [{items}])`
 Inserts multiple items into the database.
 Requires a `model [Model]` and `item [Object array]`.
-Returns `true` if the operation was successfull or `false` if not.
+Returns `[Array]` with the `id` of the objects inserted.
 
 - ***async*** `update(model, {values}, {filter})`
 Updates one or multiple items from the database.
@@ -151,14 +151,14 @@ mongo.createIndexes(model);
    result = await mongo.insert(model, {
       id: 1,
       value: 'sarasa'
-   }); // expected return: true
+   }); // expected return: '000000054361564751d8516f'
 
    // multiInsert
    result = await mongo.multiInsert(model, [
       { id: 1, value: 'sarasa 1' },
       { id: 2, value: 'sarasa 2' },
       { id: 3, value: 'sarasa 3' }
-   ]); // expected return: true
+   ]); // expected return: ['00000058faf66849077316ba', '00000059faf66849077316bb', '0000005afaf66849077316bc']
 
    // update
    result = await mongo.update(model,

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -362,15 +362,15 @@ class MongoDB {
 
 		const db = this.client.db(this.config.database);
 
-		const updateValues = this.prepareFields({ ...values });
+		this.prepareFields({ ...values });
 
-		this.prepareFields(updateValues);
+		this.prepareFields(values);
 		this.prepareFields(filter, true);
 
-		this.cleanFields(updateValues);
+		this.cleanFields(values);
 
 		const updateData = {
-			$set: updateValues,
+			$set: values,
 			$currentDate: { dateModified: true },
 			$setOnInsert: { dateCreated: new Date() }
 		};

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -482,7 +482,8 @@ class MongoDB {
 
 		try {
 
-			await Promise.all(stacks);
+			const result = await Promise.all(stacks);
+			const insertedIds = Object.keys(result.upsertedIds).map(id => id.toString());
 
 			return true;
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -274,7 +274,7 @@ class MongoDB {
 	 * Insert/update one element into the database
 	 * @param {Model} model Model instance
 	 * @param {Object} item item
-	 * @returns {String} ID if element
+	 * @returns {String} inserted ID / updated unique index used as filter
 	 */
 	async save(model, item = {}) {
 
@@ -303,11 +303,12 @@ class MongoDB {
 					$setOnInsert: { dateCreated: new Date() }
 				}, { upsert: true });
 
-			const uniqueIndex = res.upsertedId ?
-				res.upsertedId._id || res.upsertedId : // If the object was Inserted: Get the ID
-				filter._id; // If the object was Updated
+			const upsertId = res.upsertedId ? res.upsertedId._id : res.upsertedId; // If the object was Inserted: Get the ID
 
-			return uniqueIndex.toString();
+			// If the object was Updated, it used the filter which always is one of the unique Indexes
+			const [uniqueIndexFilter] =	Object.values(filter);
+
+			return (upsertId || uniqueIndexFilter).toString();
 
 		} catch(err) {
 			throw new MongoDBError(err.message, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
@@ -362,15 +363,15 @@ class MongoDB {
 
 		const db = this.client.db(this.config.database);
 
-		this.prepareFields({ ...values });
+		const updateValues = { ...values };
 
-		this.prepareFields(values);
+		this.prepareFields(updateValues);
 		this.prepareFields(filter, true);
 
-		this.cleanFields(values);
+		this.cleanFields(updateValues);
 
 		const updateData = {
-			$set: values,
+			$set: updateValues,
 			$currentDate: { dateModified: true },
 			$setOnInsert: { dateCreated: new Date() }
 		};

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -134,7 +134,7 @@ class MongoDB {
 	prepareFields(fields, toFilter = false) {
 
 		if(typeof fields._id === 'undefined' && typeof fields.id === 'undefined')
-			return fields;
+			return;
 
 		if(typeof fields.id !== 'undefined') {
 
@@ -145,8 +145,6 @@ class MongoDB {
 
 			delete fields.id;
 		}
-
-		return fields;
 	}
 
 	/**

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -518,7 +518,7 @@ class MongoDB {
 
 		item = this.getFilter(model, item);
 
-		item = this.prepareFields(item);
+		this.prepareFields(item);
 
 		try {
 			const res = await db.collection(model.constructor.table)
@@ -544,7 +544,7 @@ class MongoDB {
 
 		await this.checkConnection();
 
-		filter = this.prepareFields(filter);
+		this.prepareFields(filter);
 
 		const db = this.client.db(this.config.database);
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -216,6 +216,12 @@ class MongoDB {
 			model.lastQueryEmpty = !res.length;
 			model.totalsParams = { ...params };
 
+			return res.map(this.prepareFieldsForOutput);
+
+		} catch(err) {
+			throw new MongoDBError(err.message, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
+		}
+	}
 
 	/**
 	 * Compares the model with the item then returns a common filter between both
@@ -284,10 +290,10 @@ class MongoDB {
 		this.prepareFields(filter, true);
 		this.prepareFields(item);
 
-		this.cleanFields(item);
-
 		if(typeof item._id !== 'undefined') // Previene errores en el upsert
 			delete item._id;
+
+		this.cleanFields(item);
 
 		try {
 			const res = await db.collection(model.constructor.table)

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -306,7 +306,7 @@ class MongoDB {
 	 * Inserts data into the database
 	 * @param {Model} model Model instance
 	 * @param {Object} item item
-	 * @returns {Boolean} true/false
+	 * @returns {String} true/false
 	 */
 	async insert(model, item) {
 
@@ -327,7 +327,7 @@ class MongoDB {
 			const res = await db.collection(model.constructor.table)
 				.insertOne(setItem);
 
-			return !!res.result.ok;
+			return res.insertedId;
 
 		} catch(err) {
 			throw new MongoDBError(err.message, MongoDBError.codes.MONGODB_INTERNAL_ERROR);

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -129,15 +129,19 @@ class MongoDB {
 	/**
 	* Prepares the id field by mapping id into _id for data interaction with MongoDB, like getting filters and/or inserting data.
 	* @param {Object} fields item fields
+	* @returns {Object}
 	*/
 	prepareFields(fields) {
 		if(typeof fields._id === 'undefined' && typeof fields.id === 'undefined')
-			return;
+			return fields;
 
 		if(typeof fields.id !== 'undefined') {
-			fields._id = ObjectID(fields.id);
-			delete fields.id;
+			const newFields = { ...fields, _id: ObjectID(fields.id) };
+			delete newFields.id;
+			return newFields;
 		}
+
+		return fields;
 	}
 
 	/**
@@ -190,11 +194,10 @@ class MongoDB {
 
 		const page = params.page || 1;
 
-		const filters = params.filters || {};
+		const filters = this.prepareFields({ ...params.filters });
 
 		const order = params.order || { $natural: 1 };
 
-		this.prepareFields(filters);
 		this.parseSortingParams(order);
 
 		try {
@@ -267,7 +270,7 @@ class MongoDB {
 	 * Insert/update one element into the database
 	 * @param {Model} model Model instance
 	 * @param {Object} item item
-	 * @returns {String} ID if element was inserted or Unique Index used as filter if it was updated
+	 * @returns {String} ID if element
 	 */
 	async save(model, item = {}) {
 
@@ -278,24 +281,27 @@ class MongoDB {
 
 		const db = this.client.db(this.config.database);
 
-		const filter = this.getFilter(model, item);
+		let filter = this.getFilter(model, item);
 
-		this.prepareFields(filter);
-		this.prepareFields(item);
+		filter = this.prepareFields(filter);
+		const itemToSave = this.prepareFields(item);
 
-		this.cleanFields(item);
+		this.cleanFields(itemToSave);
+
+		if(typeof itemToSave._id !== 'undefined') // Previene errores en el upsert
+			delete itemToSave._id;
 
 		try {
 			const res = await db.collection(model.constructor.table)
 				.updateOne(filter, {
-					$set: item,
+					$set: itemToSave,
 					$currentDate: { lastModified: true },
 					$setOnInsert: { dateCreated: new Date() }
 				}, { upsert: true });
 
 			const uniqueIndex = res.upsertedId ?
 				res.upsertedId._id || res.upsertedId : // If the object was Inserted: Get the ID
-				Object.values(filter)[0]; // If the object was Updated: Get the Unique Index used as filter
+				item.id; // If the object was Updated
 
 			return uniqueIndex.toString();
 
@@ -323,11 +329,11 @@ class MongoDB {
 
 		setItem.dateCreated = new Date();
 
-		this.prepareFields(setItem);
+		const itemToInsert = this.prepareFields(setItem);
 
 		try {
 			const res = await db.collection(model.constructor.table)
-				.insertOne(setItem);
+				.insertOne(itemToInsert);
 
 			return res.insertedId.toString();
 
@@ -352,10 +358,9 @@ class MongoDB {
 
 		const db = this.client.db(this.config.database);
 
-		const updateValues = { ...values };
+		const updateValues = this.prepareFields({ ...values });
 
-		this.prepareFields(updateValues);
-		this.prepareFields(filter);
+		filter = this.prepareFields(filter);
 
 		this.cleanFields(updateValues);
 
@@ -394,14 +399,15 @@ class MongoDB {
 
 		const db = this.client.db(this.config.database);
 
-		items.forEach(item => {
-			this.prepareFields(item);
-			item.dateCreated = new Date();
+		const itemsToInserts = items.map(item => {
+			const itemToInsert = this.prepareFields(item);
+			itemToInsert.dateCreated = new Date();
+			return itemToInsert;
 		});
 
 		try {
 			const res = await db.collection(model.constructor.table)
-				.insertMany(items);
+				.insertMany(itemsToInserts);
 
 			return Object.values(res.insertedIds).map(id => id.toString());
 
@@ -415,7 +421,7 @@ class MongoDB {
 	 * @param {Model} model Model instance
 	 * @param {Array} items items
 	 * @param {Number} limit specifies the limit of items that can be bulk writed into monogdb at the same time
-	 * @returns {Boolean} true/false
+	 * @returns {Array<String>} Array with ID of items inserted/updated
 	 */
 	async multiSave(model, items, limit = 1000) {
 
@@ -431,18 +437,18 @@ class MongoDB {
 
 		const updateItems = items.map(item => {
 
-			const filter = this.getFilter(model, item);
+			let filter = this.getFilter(model, item);
 
-			this.prepareFields(item);
-			this.prepareFields(filter);
+			const itemToSave = this.prepareFields(item);
+			filter = this.prepareFields(filter);
 
-			if(typeof item._id !== 'undefined') // Previene errores en el upsert
-				delete item._id;
+			if(typeof itemToSave._id !== 'undefined') // Previene errores en el upsert
+				delete itemToSave._id;
 
-			this.cleanFields(item);
+			this.cleanFields(itemToSave);
 
 			const update = {
-				$set: item,
+				$set: itemToSave,
 				$currentDate: { lastModified: true },
 				$setOnInsert: { dateCreated: new Date() }
 			};
@@ -452,7 +458,8 @@ class MongoDB {
 		}).filter(Boolean);
 
 		if(!updateItems.length)
-			return false;
+			return [];
+
 
 		const itemStacks = [];
 		const stacks = [];
@@ -482,10 +489,21 @@ class MongoDB {
 
 		try {
 
-			const result = await Promise.all(stacks);
-			const insertedIds = Object.keys(result.upsertedIds).map(id => id.toString());
+			const [result] = await Promise.all(stacks);
 
-			return true;
+			const { modifiedCount, upsertedCount, upsertedIds } = result;
+
+			// No updates, only inserts
+			if(!modifiedCount && upsertedCount)
+				return Object.values(upsertedIds).map(id => id.toString());
+
+			return items.map((item, i) => {
+				// Check if item was inserted
+				if(upsertedIds[i])
+					return upsertedIds[i].toString();
+				// Item updated
+				return item.id;
+			});
 
 		} catch(err) {
 			throw new MongoDBError(err.message, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
@@ -509,7 +527,7 @@ class MongoDB {
 
 		item = this.getFilter(model, item);
 
-		this.prepareFields(item);
+		item = this.prepareFields(item);
 
 		try {
 			const res = await db.collection(model.constructor.table)
@@ -535,7 +553,7 @@ class MongoDB {
 
 		await this.checkConnection();
 
-		this.prepareFields(filter);
+		filter = this.prepareFields(filter);
 
 		const db = this.client.db(this.config.database);
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -327,7 +327,7 @@ class MongoDB {
 			const res = await db.collection(model.constructor.table)
 				.insertOne(setItem);
 
-			return res.insertedId;
+			return res.insertedId.toString();
 
 		} catch(err) {
 			throw new MongoDBError(err.message, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
@@ -378,7 +378,7 @@ class MongoDB {
 	 * Multi insert items into the dabatase
 	 * @param {Model} model Model instance
 	 * @param {Array} items items
-	 * @returns {Boolean} true/false
+	 * @returns {Array<String>} Array with the ID inserted
 	 */
 	async multiInsert(model, items) {
 
@@ -401,7 +401,7 @@ class MongoDB {
 			const res = await db.collection(model.constructor.table)
 				.insertMany(items);
 
-			return !!res.result.ok;
+			return Object.values(res.insertedIds).map(id => id.toString());
 
 		} catch(err) {
 			throw new MongoDBError(err.message, MongoDBError.codes.MONGODB_INTERNAL_ERROR);

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -255,6 +255,7 @@ class MongoDB {
 	}
 
 	cleanFields(fields) {
+
 		if(typeof fields.dateCreated !== 'undefined')
 			delete fields.dateCreated;
 
@@ -266,7 +267,7 @@ class MongoDB {
 	 * Insert/update one element into the database
 	 * @param {Model} model Model instance
 	 * @param {Object} item item
-	 * @returns {Boolean} true/false
+	 * @returns {String} ID if element was inserted or Unique Index used as filter if it was updated
 	 */
 	async save(model, item = {}) {
 
@@ -282,9 +283,6 @@ class MongoDB {
 		this.prepareFields(filter);
 		this.prepareFields(item);
 
-		if(typeof item._id !== 'undefined') // Previene errores en el upsert
-			delete item._id;
-
 		this.cleanFields(item);
 
 		try {
@@ -295,7 +293,11 @@ class MongoDB {
 					$setOnInsert: { dateCreated: new Date() }
 				}, { upsert: true });
 
-			return res.matchedCount === 1 || res.upsertedCount === 1;
+			const uniqueIndex = res.upsertedId ?
+				res.upsertedId._id || res.upsertedId : // If the object was Inserted: Get the ID
+				Object.values(filter)[0]; // If the object was Updated: Get the Unique Index used as filter
+
+			return uniqueIndex.toString();
 
 		} catch(err) {
 			throw new MongoDBError(err.message, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
@@ -306,7 +308,7 @@ class MongoDB {
 	 * Inserts data into the database
 	 * @param {Model} model Model instance
 	 * @param {Object} item item
-	 * @returns {String} true/false
+	 * @returns {String} ID of the object inserted
 	 */
 	async insert(model, item) {
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -197,7 +197,7 @@ class MongoDB {
 
 		const page = params.page || 1;
 
-		const filters = this.prepareFields({ ...params.filters });
+		const filters = params.filters || {};
 
 		const order = params.order || { $natural: 1 };
 
@@ -216,12 +216,6 @@ class MongoDB {
 			model.lastQueryEmpty = !res.length;
 			model.totalsParams = { ...params };
 
-			return res.map(this.prepareFieldsForOutput);
-
-		} catch(err) {
-			throw new MongoDBError(err.message, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
-		}
-	}
 
 	/**
 	 * Compares the model with the item then returns a common filter between both

--- a/tests/mongodb-test.js
+++ b/tests/mongodb-test.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const sandbox = require('sinon').createSandbox();
 const mockRequire = require('mock-require');
+const MongoDriver = require('mongodb');
 
 mockRequire('mongodb', 'mongo-mock');
 
@@ -314,7 +315,7 @@ describe('MongoDB', () => {
 
 			const result = await mongodb.insert(model, {	value: 'insert_test_data' });
 
-			assert.deepEqual(result, true);
+			assert(MongoDriver.ObjectID.isValid(result));
 
 			await clearMockedDatabase();
 		});

--- a/tests/mongodb-test.js
+++ b/tests/mongodb-test.js
@@ -473,9 +473,10 @@ describe('MongoDB', () => {
 				{ id: 3, value: 'multiInsert_test_data' }
 			];
 
-			const result = await mongodb.multiInsert(model, items);
+			const results = await mongodb.multiInsert(model, items);
 
-			assert.deepEqual(result, true);
+			for(const result of results)
+				assert(MongoDriver.ObjectID.isValid(result));
 
 			items = await mongodb.get(model, { filters: { value: 'multiInsert_test_data' } });
 

--- a/tests/mongodb-test.js
+++ b/tests/mongodb-test.js
@@ -444,6 +444,36 @@ describe('MongoDB', () => {
 
 		});
 
+		it('should return unique Index (not ID) when try to save with that unique Index', async () => {
+
+			const itemToSave = { id: 1, unique: 'Not Equal', value: 'save_test_data' };
+
+			// Insert
+			let result = await mongodb.save(model, itemToSave);
+			assert.deepEqual(MongoDriver.ObjectID.isValid(result), true);
+
+			const itemSaved = await mongodb.get(model, { filters: { value: itemToSave.value } });
+			assert.deepEqual(itemSaved[0].value, itemToSave.value);
+			assert.deepEqual(itemSaved[0].unique, itemToSave.unique);
+
+			const itemToUpdate = { unique: itemToSave.unique, value: 'save_test_data_updated' };
+
+			// Update
+			result = await mongodb.save(model, itemToUpdate);
+			assert.deepEqual(result, itemToUpdate.unique);
+
+			const itemUpdated = await mongodb.get(model, { filters: { value: itemToUpdate.value } });
+			assert.deepEqual(itemUpdated[0].value, itemToUpdate.value);
+			assert.deepEqual(itemUpdated[0].unique, itemToUpdate.unique);
+
+			// Should be the same
+			assert.deepEqual(itemUpdated[0].unique, itemSaved[0].unique);
+			assert.deepEqual(itemUpdated[0].id, itemSaved[0].id);
+
+			await clearMockedDatabase();
+
+		});
+
 		it('should insert an item and auto fix \'_id\' unexpected fields when save an item', async () => {
 
 			const result = await mongodb.save(model, { id: undefined, value: 'save_test_data' });


### PR DESCRIPTION
**JCN-140-mongodb-debe-retornar-id-al-insertar**
JCN- 140 mongodb debe retornar id al insertar

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-140

**DESCRIPCIÓN DEL REQUERIMIENTO**
1.1 - Se requiere actualizar el paquete de MongoDB
1.2 - Se requiere que al insertar un registro devuelva la ID del mismo en la base de datos.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollo el paquete con los requerimientos solicitados. Y además se cambió `save`, el `multiSave` y `multiInsert` los deje como estaban. Se actualizó con el cambio de la estandarización de las fechas. 