### PR TITLE
JCN-145-estandarizacion-de-fechas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Modified
+- `lastModified` field name was changed into `dateModified`
+
 ## [1.3.0] - 2019-07-30
 ### Added
 - Order parameter for `get()` method

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -258,8 +258,8 @@ class MongoDB {
 		if(typeof fields.dateCreated !== 'undefined')
 			delete fields.dateCreated;
 
-		if(typeof fields.lastModified !== 'undefined')
-			delete fields.lastModified;
+		if(typeof fields.dateModified !== 'undefined')
+			delete fields.dateModified;
 	}
 
 	/**
@@ -291,7 +291,7 @@ class MongoDB {
 			const res = await db.collection(model.constructor.table)
 				.updateOne(filter, {
 					$set: item,
-					$currentDate: { lastModified: true },
+					$currentDate: { dateModified: true },
 					$setOnInsert: { dateCreated: new Date() }
 				}, { upsert: true });
 
@@ -359,7 +359,7 @@ class MongoDB {
 
 		const updateData = {
 			$set: updateValues,
-			$currentDate: { lastModified: true },
+			$currentDate: { dateModified: true },
 			$setOnInsert: { dateCreated: new Date() }
 		};
 
@@ -441,7 +441,7 @@ class MongoDB {
 
 			const update = {
 				$set: item,
-				$currentDate: { lastModified: true },
+				$currentDate: { dateModified: true },
 				$setOnInsert: { dateCreated: new Date() }
 			};
 

--- a/tests/mongodb-test.js
+++ b/tests/mongodb-test.js
@@ -803,11 +803,11 @@ describe('MongoDB', () => {
 
 	describe('cleanFields()', () => {
 
-		it('should remove lastModified and dateCreated from the specified field', () => {
+		it('should remove dateModified and dateCreated from the specified field', () => {
 
 			const fields = {
 				value: 'sarasa',
-				lastModified: 'something',
+				dateModified: 'something',
 				dateCreated: 'something'
 			};
 


### PR DESCRIPTION
**JCN-145-ESTANDARIZACION-DE-FECHAS**
JCN-145 MongoDB debe estandarizar fechas

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-145

**DESCRIPCIÓN DEL REQUERIMIENTO**
1.1 - Modificar si corresponde  el driver de `MongoDB` para que contenga `dateCreated` para las fechas de creación de un elemento nuevo.
1.2 - Modificar si corresponde  el driver de `MongoDB` para que contenga `dateModified` para las fechas de edición de un elemento existente.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se cambio el nombre de los cambios de fecha de modificacion, de `lastModified` a `dateModified`