### PR TITLE
JCN-155-validacion-de-configuracion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `config-validator` module
+- `MongoDBConfigError` module
+- config validations
 
 ## [1.3.3] - 2019-08-29
-## Fixed
+### Fixed
 - Now `insert` returns ID of the object inserted, as it was expected
 - Now `save` returns ID of the object if it was inserted / Unique Index used as filter if it was updated, as it was expected
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,23 @@ npm install --save @janiscommerce/mongodb
 - `new MongoDB({config})`
 Constructs the MongoDB driver instance, connected with the `config [Object]`.
 
-Config usage:
+**Config validations:**  
+
+- host `[String]` (optional): MongoDB host, default: `localhost`  
+- protocol `[String]` (optional): host protocol, default: `mongodb://`  
+- port `[Number]` (optional): host port, default: `27017`  
+- user `[String]` (optional): host username, default none  
+- password `[String]` (optional): host user password, default none  
+- database `[String]` **(required)**: MongoDB database
+- limit `[Number]` (optional): Limit for `get`/`getTotals` operations, default: `500`  
+
+**Config usage:**
 ```js
 {
-   protocol: 'mongodb://', // Default "mongodb://"
-   host: 'localhost', // Default "localhost"
-   port: 27017, // Default 27017
-   limit: 500, // Default 500
+   protocol: 'mongodb://',
+   host: 'localhost',
+   port: 27017,
+   limit: 500,
    user: 'fizzmod',
    password: 'sarasa',
    database: 'myDB'
@@ -112,7 +122,7 @@ Returns `deletedCount [Number]`.
 ## Errors
 
 The errors are informed with a `MongoDBError`.
-This object has a code that can be useful for a correct error handling.
+This object has a code that can be useful for a correct error handling.  
 The codes are the following:
 
 | Code | Description                    |
@@ -121,8 +131,17 @@ The codes are the following:
 | 2    | Empty unique indexes           |
 | 3    | Invalid or empty model         |
 | 4    | Internal mongodb error         |
-| 5    | Invalid config                 |
-| 6    | Invalid item                   |
+| 5    | Invalid item                   |
+
+The config validation errors are informed with a `MongoDBConfigError`
+This object has a code that can be useful for a correct error handling.  
+The codes are the following:
+
+| Code | Description                    |
+|------|--------------------------------|
+| 1    | Invalid config                 |
+| 2    | Invalid setting                |
+| 3    | Required setting               |
 
 ## Usage
 

--- a/lib/config-validator.js
+++ b/lib/config-validator.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const MongoDBConfigError = require('./mongodb-config-error');
+
+const MONGODB_CONFIG_STRUCT = {
+	protocol: {
+		type: 'string'
+	},
+	host: {
+		type: 'string'
+	},
+	port: {
+		type: 'number'
+	},
+	user: {
+		type: 'string'
+	},
+	password: {
+		type: 'string'
+	},
+	database: {
+		type: 'string',
+		required: true
+	},
+	limit: {
+		type: 'number'
+	}
+};
+
+/**
+ * @class ConfigValidator
+ * @classdesc Validates config struct
+ */
+class ConfigValidator {
+
+	/**
+     * Validate the received config struct
+     * @throws if the struct is invalid
+     */
+	static validate(config) {
+
+		if(!config || typeof config !== 'object' || Array.isArray(config))
+			throw new MongoDBConfigError('Invalid config: Should be an object.', MongoDBConfigError.codes.INVALID_CONFIG);
+
+		for(const [setting, terms] of Object.entries(MONGODB_CONFIG_STRUCT)) {
+
+			switch(typeof config[setting]) {
+
+				case terms.type:
+					break;
+
+				case 'undefined':
+					if(terms.required)
+						throw new MongoDBConfigError(`Invalid config: '${setting}' is required.`, MongoDBConfigError.codes.REQUIRED_SETTING);
+					break;
+
+				default:
+					throw new MongoDBConfigError(`Invalid setting '${setting}': Expected ${terms.type} but received ${typeof config[setting]}.`,
+						MongoDBConfigError.codes.INVALID_SETTING);
+
+			}
+
+		}
+
+	}
+
+}
+
+module.exports = ConfigValidator;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,10 @@
 
 const MongoDB = require('./mongodb');
 const MongoDBError = require('./mongodb-error');
+const MongoDBConfigError = require('./mongodb-config-error');
 
 module.exports = {
 	MongoDB,
-	MongoDBError
+	MongoDBError,
+	MongoDBConfigError
 };

--- a/lib/mongodb-config-error.js
+++ b/lib/mongodb-config-error.js
@@ -1,0 +1,23 @@
+'use strict';
+
+class MongoDBConfigError extends Error {
+
+	static get codes() {
+
+		return {
+			INVALID_CONFIG: 1,
+			INVALID_SETTING: 2,
+			REQUIRED_SETTING: 3
+		};
+
+	}
+
+	constructor(err, code) {
+		super(err);
+		this.message = err.message || err;
+		this.code = code;
+		this.name = 'MongoDBConfigError';
+	}
+}
+
+module.exports = MongoDBConfigError;

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -8,6 +8,8 @@ const logger = require('@janiscommerce/logger');
 
 const MongoDBError = require('./mongodb-error');
 
+const ConfigValidator = require('./config-validator');
+
 const DEFAULT_LIMIT = 500;
 
 const MONGODB_DEFAULT_PROTOCOL = 'mongodb://';
@@ -21,8 +23,8 @@ const MONGODB_DEFAULT_HOST = 'localhost';
 class MongoDB {
 
 	constructor(config) {
-		if(!config || typeof config !== 'object' || Array.isArray(config))
-			throw new MongoDBError('Invalid config', MongoDBError.codes.INVALID_CONFIG);
+
+		ConfigValidator.validate(config);
 
 		this.config = {
 			protocol: config.protocol || MONGODB_DEFAULT_PROTOCOL,
@@ -30,9 +32,10 @@ class MongoDB {
 			port: config.port || 27017,
 			user: config.user || '',
 			password: config.password || '',
-			database: config.database || '',
+			database: config.database,
 			limit: config.limit || DEFAULT_LIMIT
 		};
+
 		// Avoid protocol duplication
 		this.config.host = this.config.host.replace(this.config.protocol, '');
 	}


### PR DESCRIPTION
**JCN-155-VALIDACION-DE-CONFIGURACION**
JCN-155 Validación de configuración para construir el Driver

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-155

**DESCRIPCIÓN DEL REQUERIMIENTO**
4.1. Validar campos de configuración que se usan en el `constructor()`
4.2. Validar existencia, tipo de datos, etcs
4.3. Agregar nueva clase MongoDBConfigError para el error handling
4.4. Documentar la nueva funcionalidad.
4.5. 100% de código testeado.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se realizaron los requerimientos solicitados