### PR TITLE
JAN-733-multiple-filters

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -306,7 +306,7 @@ class MongoDB {
 			const upsertId = res.upsertedId ? res.upsertedId._id : res.upsertedId; // If the object was Inserted: Get the ID
 
 			// If the object was Updated, it used the filter which always is one of the unique Indexes
-			const [uniqueIndexFilter] =	filters._id ? [filters._id] : Object.values(filters);
+			const [uniqueIndexFilter] = filters._id ? [filters._id] : Object.values(filters);
 
 			return (upsertId || uniqueIndexFilter).toString();
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -230,7 +230,7 @@ class MongoDB {
 	 * @returns {Object} filter
 	 * @throws if there isn't a common filter between the model and the item
 	 */
-	getFilter(model, item) {
+	getFilters(model, item) {
 
 		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
@@ -240,25 +240,25 @@ class MongoDB {
 				MongoDBError.codes.MODEL_EMPTY_UNIQUE_INDEXES);
 		}
 
-		let filter;
+		let filters = {};
 
 		for(let index of model.constructor.uniqueIndexes) {
 
 			if(!Array.isArray(index))
 				index = [index];
 
-			filter = pick(item, index);
+			const filter = pick(item, index);
 
-			if(Object.keys(filter).length === index.length)
-				break;
+			if(Object.keys(filter).length !== index.length)
+				continue;
 
-			filter = {};
+			filters = { ...filters, ...filter };
 		}
 
-		if(!Object.keys(filter).length)
+		if(!Object.keys(filters).length)
 			throw new MongoDBError(`Operation requires unique indexes. See ${model.constructor.name}.uniqueIndexes`, MongoDBError.codes.EMPTY_UNIQUE_INDEXES);
 
-		return filter;
+		return filters;
 	}
 
 	cleanFields(fields) {
@@ -285,9 +285,9 @@ class MongoDB {
 
 		const db = this.client.db(this.config.database);
 
-		const filter = this.getFilter(model, item);
+		const filters = this.getFilters(model, item);
 
-		this.prepareFields(filter, true);
+		this.prepareFields(filters, true);
 		this.prepareFields(item);
 
 		if(typeof item._id !== 'undefined') // Previene errores en el upsert
@@ -297,7 +297,7 @@ class MongoDB {
 
 		try {
 			const res = await db.collection(model.constructor.table)
-				.updateOne(filter, {
+				.updateOne(filters, {
 					$set: item,
 					$currentDate: { dateModified: true },
 					$setOnInsert: { dateCreated: new Date() }
@@ -306,7 +306,7 @@ class MongoDB {
 			const upsertId = res.upsertedId ? res.upsertedId._id : res.upsertedId; // If the object was Inserted: Get the ID
 
 			// If the object was Updated, it used the filter which always is one of the unique Indexes
-			const [uniqueIndexFilter] =	Object.values(filter);
+			const [uniqueIndexFilter] =	filters._id ? [filters._id] : Object.values(filters);
 
 			return (upsertId || uniqueIndexFilter).toString();
 
@@ -442,10 +442,10 @@ class MongoDB {
 
 		const updateItems = items.map(item => {
 
-			const filter = this.getFilter(model, item);
+			const filters = this.getFilters(model, item);
 
 			this.prepareFields(item);
-			this.prepareFields(filter, true);
+			this.prepareFields(filters, true);
 
 			if(typeof item._id !== 'undefined') // Previene errores en el upsert
 				delete item._id;
@@ -458,7 +458,7 @@ class MongoDB {
 				$setOnInsert: { dateCreated: new Date() }
 			};
 
-			return { updateOne: { filter, update, upsert: true } };
+			return { updateOne: { filters, update, upsert: true } };
 
 		}).filter(Boolean);
 
@@ -517,7 +517,7 @@ class MongoDB {
 
 		const db = this.client.db(this.config.database);
 
-		item = this.getFilter(model, item);
+		item = this.getFilters(model, item);
 
 		this.prepareFields(item);
 

--- a/tests/mongodb-test.js
+++ b/tests/mongodb-test.js
@@ -303,7 +303,7 @@ describe('MongoDB', () => {
 		});
 	});
 
-	describe('getFilter()', () => {
+	describe('getFilters()', () => {
 
 		it('should return non empty filter object when get filters with an array as parameter', () => {
 
@@ -311,14 +311,14 @@ describe('MongoDB', () => {
 				return [['id']];
 			});
 
-			const result = mongodb.getFilter(model, { id: 1 });
+			const result = mongodb.getFilters(model, { id: 1 });
 
 			assert.deepEqual(result.id, 1);
 		});
 
 		it('should return non empty filter object when get filters with an object as parameter', () => {
 
-			const result = mongodb.getFilter(model, { id: 1 });
+			const result = mongodb.getFilters(model, { id: 1 });
 
 			assert.deepEqual(result.id, 1);
 		});
@@ -326,7 +326,7 @@ describe('MongoDB', () => {
 		it('should throw when get filters with a model without unique indexes', () => {
 
 			assert.throws(() => {
-				mongodb.getFilter({});
+				mongodb.getFilters({});
 			}, {
 				name: 'MongoDBError',
 				code: MongoDBError.codes.MODEL_EMPTY_UNIQUE_INDEXES
@@ -336,7 +336,7 @@ describe('MongoDB', () => {
 		it('should throw when try to get filters and the model unique indexes not matches with any of the filters', () => {
 
 			assert.throws(() => {
-				mongodb.getFilter(model);
+				mongodb.getFilters(model);
 			}, {
 				name: 'MongoDBError',
 				code: MongoDBError.codes.EMPTY_UNIQUE_INDEXES
@@ -346,7 +346,7 @@ describe('MongoDB', () => {
 
 		it('should throw when get filters with an invalid model', () => {
 			assert.throws(() => {
-				mongodb.getFilter();
+				mongodb.getFilters();
 			}, {
 				name: 'MongoDBError',
 				code: MongoDBError.codes.INVALID_MODEL


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JAN-733

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se propone agregar la funcionalidad para que el `save, multiSave, remove`, se agreguen como filtros de busqueda los que se tengan seteados en el modelo como `uniqueIndexes`. 

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se cambio el nombre del método y de los llamados del mismo en todos los casos, se agregaron todos los filtros cuando se recorre el `array` de `uniqueIndexes` y se retornan estos. Por otro lado en el `save` al momento de retornar el valor se pregunta si existe el filtro `_id` y en caso de ser así se retorna, en caso contrario se retorna el primer valor de los filtros.

**INFORMACION ADICIONAL**
Esto es solo una propuesta ya lo encontré necesario en events de acuerdo a lo que se muestra en la tarea, con lo cual y en todo caso si no es retrocompatible la propuesta, haré el get y posterior el save con el `_id`