### PR TITLE
Jcn 160 filter mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2019-09-25
+### Added
+- `filter-wrapper` Module
+- Model filter handling
+
 ## [1.4.0] - 2019-09-12
 ### Added
 - `config-validator` module

--- a/README.md
+++ b/README.md
@@ -106,11 +106,98 @@ Parameters example:
    filters: {
       itemField: 'foobar',
       otherItemField: {
-         $in: ['foo', 'bar']
-      },
+         'value': ['foo', 'bar'],
+         'type' : 'in'
+      }
    }
 }
 ```
+##### Filters
+
+The filters has a structure to apply, by default uses `equal`.
+For example:
+```js
+{
+   filters: {
+    'aField': 'valueToFilter'
+   }
+}
+```
+Transforms to:
+```js
+{
+   <aField>: { $eq: <valueToFilter> }
+}
+```
+If you want to apply different filters it should be as follows:
+```js
+{
+    filters: {
+        'aField': { 
+            value: 'valueToFilter', // required(string or array)
+            type: 'aTypeChoosen' //optional
+        }
+   }
+}
+```
+
+The possible types to use are:
+
+| Filter        | Mongo filter          |
+|---------------|-----------------------|
+| equal         | $eq                   |
+| not           | $ne                   |
+| greater       | $gt                   |
+| greaterOrEqual| $gte                  |
+| lesser        | $lt                   |
+| lesserOrEqual | $lte                  |
+| in            | $in                   |
+| notIn         | $nin                  |
+| reg           | $reg                  |
+| all           | $all                  |
+
+
+You can also add filters in the model defining the `fields` function as follow:
+```js
+static get fields() {
+    return {
+        'aFieldWithName': {
+            type: 'aTypeDefined',
+            field: 'fieldInMongoDB'
+        },
+        'anotherFieldName': {
+            type: 'aTypeDefined',
+            field: 'fieldInMongoDB'
+        },
+        {
+            ...
+        }
+    }
+}
+```
+In which we have:
+
+`afieldWithName` and `anotherFieldName` as name default in Model <br/>
+`aTypeDefined` as a possible type to use as filter<br/>
+`fieldInMongoDB` as the field in MongoDB to compare<br/>
+
+For example:
+
+```js
+static get fields() {
+    return {
+        date_from: {
+            type: 'greaterOrEqual',
+            field: 'date'
+        },
+        date_from_g: {
+            type: 'greater',
+            field: 'date'
+        }
+    }
+}
+```
+
 
 ### ***async*** `getTotals(model)`
 Get the totals of the items from the latest get operation with pagination.

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,9 +3,11 @@
 const MongoDB = require('./mongodb');
 const MongoDBError = require('./mongodb-error');
 const MongoDBConfigError = require('./mongodb-config-error');
+const MongoDBFilterWrapper = require('./mongodb-filter-wrapper');
 
 module.exports = {
 	MongoDB,
 	MongoDBError,
-	MongoDBConfigError
+	MongoDBConfigError,
+	MongoDBFilterWrapper
 };

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -3,35 +3,119 @@
 class MongoDBFilterWrapper {
 	static get filtersAllowed() {
 		return {
-			notEqual: '$not',
+			equal: '$eq',
+			not: '$ne',
 			greater: '$gt',
 			greaterOrEqual: '$gte',
 			lesser: '$lt',
-			lesserOrEqual: '$lte'
+			lesserOrEqual: '$lte',
+			in: '$in',
+			notIn: '$nin',
+			reg: '$regex',
+			all: '$all'
 		};
 	}
 
-	static process(model, filters) {
-		const filtersToReturn = {};
-		// eslint-disable-next-line guard-for-in,no-restricted-syntax
-		for(const aFilter in filters) {
-			const conditionFilter = (model.constructor && model.constructor.fields) ? model.constructor.fields[aFilter] : '';
-			if(conditionFilter && conditionFilter.type !== undefined) {
-				// MongoDBFilterWrapper.filtersAllowed.indexOf(aFilter);
-				const mongoCond = MongoDBFilterWrapper.filtersAllowed[conditionFilter.type];
-				if(mongoCond) {
-					const filterCol = conditionFilter.field ? conditionFilter.field : aFilter;
-					const aUse = {
-						[mongoCond]: filters[aFilter]
-					};
-					filtersToReturn[filterCol] = aUse;
-				}
-			}
-		}
+	static process(model, filtersDefined) {
+		let modelFilters = {};
 
-		return filtersToReturn;
+		// Get model filters
+		if(model.constructor && model.constructor.fields)
+			modelFilters = model.constructor.fields;
+
+		return MongoDBFilterWrapper.parseFiltersDefined(filtersDefined, modelFilters);
 	}
 
+	static parseFiltersDefined(filtersGiven, modelFilters) {
+		let filters = {};
+		const filtersArray = [];
+		let filtersToLoop = {};
+		let orCondition = false;
+
+		if(Array.isArray(filtersGiven))
+			orCondition = true;
+
+		// Get only with objects as a filter
+		if(filtersGiven !== undefined && typeof filtersGiven === 'object' && Object.keys(filtersGiven).length > 0 && !Array.isArray(filtersGiven))
+			filtersToLoop = [filtersGiven];
+		else if(filtersGiven !== undefined && Array.isArray(filtersGiven))
+			filtersToLoop = filtersGiven;
+
+		if(Array.isArray(filtersToLoop) && filtersToLoop.length > 0) {
+			// First loop over all filters given by parameters
+			filtersToLoop.forEach(filterGiven => {
+				const formedFilter = MongoDBFilterWrapper.parseObjectFilter(filterGiven, modelFilters);
+
+				if(orCondition)
+					filtersArray.push(formedFilter);
+				else
+					filters = Object.assign(filters, formedFilter);
+
+			});
+		}
+
+		if(orCondition) {
+			return {
+				$or: filtersArray
+			};
+		}
+
+		return filters;
+	}
+
+	static parseObjectFilter(filterComplete, modelFilters) {
+		const filterToResponse = {};
+
+		// for(const col in filterComplete) {
+		for(const [col, value] of Object.entries(filterComplete)) {
+			const field = MongoDBFilterWrapper.getFieldToCompare(col, modelFilters);
+
+			if(typeof value === 'object')
+				filterToResponse[field] = MongoDBFilterWrapper.createFilter(col, value, modelFilters[col]);
+			else
+				filterToResponse[field] = MongoDBFilterWrapper.createFilter(col, { value }, modelFilters[col]);
+		}
+		return filterToResponse;
+	}
+
+	static createFilter(col, filterToParse, modelFilters) {
+		const type = MongoDBFilterWrapper.getFilterType(filterToParse, modelFilters);
+		const value = MongoDBFilterWrapper.getValue(filterToParse);
+
+		if(type === 'equal')
+			return value;
+
+		return {
+			[MongoDBFilterWrapper.filtersAllowed[type]]: value
+		};
+	}
+
+	static getValue(filterToUse) {
+		let result = '';
+
+		if(typeof filterToUse === 'object' && filterToUse.value === undefined)
+			result = filterToUse.str;
+
+		if(filterToUse.value !== undefined)
+			result = filterToUse.value;
+
+		return result;
+	}
+
+	static getFilterType(filterComplete, modelFilters) {
+		let type = 'equal';
+
+		if(filterComplete && filterComplete.type !== undefined)
+			({ type } = filterComplete);
+		else if(modelFilters && modelFilters.type !== undefined)
+			({ type } = modelFilters);
+
+		return type;
+	}
+
+	static getFieldToCompare(col, modelFilters) {
+		return (modelFilters[col] && modelFilters[col].field) ? modelFilters[col].field : col;
+	}
 }
 
 module.exports = MongoDBFilterWrapper;

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -81,12 +81,12 @@ class MongoDBFilterWrapper {
 	static parseObjectFilter(filters, modelFields) {
 		const filterToResponse = {};
 
-		for(const [field] of Object.entries(filters)) {
+		for(const [field, value] of Object.entries(filters)) {
 			const fieldName = this.getFieldToCompare(field, modelFields);
 
-			const value = (typeof filters[field] !== 'object') ? { value: filters[field] } : filters[field];
+			const filter = (typeof filters[field] !== 'object') ? { value } : value;
 
-			filterToResponse[fieldName] = this.createFilter(value, modelFields[field]);
+			filterToResponse[fieldName] = this.createFilter(filter, modelFields[field]);
 		}
 		return filterToResponse;
 	}

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -16,6 +16,12 @@ class MongoDBFilterWrapper {
 		};
 	}
 
+	/**
+		* Enter door to filter process
+		* @param model
+		* @param filtersDefined
+		* @returns {{$or}|{}}
+		*/
 	static process(model, filtersDefined) {
 		let modelFilters = {};
 
@@ -26,6 +32,12 @@ class MongoDBFilterWrapper {
 		return MongoDBFilterWrapper.parseFiltersDefined(filtersDefined, modelFilters);
 	}
 
+	/**
+		* Validates filters given and loop calling to parse
+		* @param filtersGiven
+		* @param modelFilters
+		* @returns {{$or: Array}}
+		*/
 	static parseFiltersDefined(filtersGiven, modelFilters) {
 		let filters = {};
 		const filtersArray = [];
@@ -63,6 +75,11 @@ class MongoDBFilterWrapper {
 		return filters;
 	}
 
+	/**
+		* Parse the filter comparing given fields name and model fields
+		* @param filterComplete
+		* @param modelFilters
+		*/
 	static parseObjectFilter(filterComplete, modelFilters) {
 		const filterToResponse = {};
 
@@ -78,6 +95,13 @@ class MongoDBFilterWrapper {
 		return filterToResponse;
 	}
 
+	/**
+		* Creates the object or the value(string/array) to use in the filter
+		* @param col
+		* @param filterToParse
+		* @param modelFilters
+		* @returns {string|{}}
+		*/
 	static createFilter(col, filterToParse, modelFilters) {
 		const type = MongoDBFilterWrapper.getFilterType(filterToParse, modelFilters);
 		const value = MongoDBFilterWrapper.getValue(filterToParse);
@@ -90,6 +114,12 @@ class MongoDBFilterWrapper {
 		};
 	}
 
+	/**
+		* Gets the value to use in the filter, if is a object(suposse ID) transform to string
+		* else search that exists the key value to return, or only returns an empty string
+		* @param filterToUse
+		* @returns {string}
+		*/
 	static getValue(filterToUse) {
 		let result = '';
 
@@ -102,6 +132,12 @@ class MongoDBFilterWrapper {
 		return result;
 	}
 
+	/**
+		* Transforms the type given in the filter to a filter used in MongoDB
+		* @param filterComplete
+		* @param modelFilters
+		* @returns {string}
+		*/
 	static getFilterType(filterComplete, modelFilters) {
 		let type = 'equal';
 
@@ -113,6 +149,13 @@ class MongoDBFilterWrapper {
 		return type;
 	}
 
+	/**
+		* Returns the field to use in filter, if is defined in the Model returns
+		* the field setted, else returns the col given in the filter
+		* @param col
+		* @param modelFilters
+		* @returns {string|filters.field|{type, value}|string}
+		*/
 	static getFieldToCompare(col, modelFilters) {
 		return (modelFilters[col] && modelFilters[col].field) ? modelFilters[col].field : col;
 	}

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -18,133 +18,129 @@ class MongoDBFilterWrapper {
 
 	/**
 		* Enter door to filter process
-		* @param model
-		* @param filtersDefined
-		* @returns {{$or}|{}}
+		* @param modelFields Object Model that will use the filter
+		* @param filters Object Filters defined as parameters
+		* @returns {{$or}|{}} Object with the filter parsed
 		*/
-	static process(model, filtersDefined) {
+	static process(modelFields, filters) {
 		let modelFilters = {};
 
 		// Get model filters
-		if(model.constructor && model.constructor.fields)
-			modelFilters = model.constructor.fields;
+		if(modelFields.constructor && modelFields.constructor.fields)
+			modelFilters = modelFields.constructor.fields;
 
-		return MongoDBFilterWrapper.parseFiltersDefined(filtersDefined, modelFilters);
+		// Get model filters
+		if(typeof filters !== 'object' || filters.length === 0)
+			return {};
+
+		return this.getParsedFilters(filters, modelFilters);
 	}
 
 	/**
 		* Validates filters given and loop calling to parse
-		* @param filtersGiven
-		* @param modelFilters
-		* @returns {{$or: Array}}
+		* @returns parsedFilters Array|Object The filter parsed to use in MongoDB
+		* @param filters Object Filters defined as parameters
+		* @param modelFields Object Model that will use the filter
 		*/
-	static parseFiltersDefined(filtersGiven, modelFilters) {
-		let filters = {};
-		const filtersArray = [];
-		let filtersToLoop = {};
+	static getParsedFilters(filters, modelFields) {
 		let orCondition = false;
 
-		if(Array.isArray(filtersGiven))
+		if(Array.isArray(filters))
 			orCondition = true;
 
-		// Get only with objects as a filter
-		if(filtersGiven !== undefined && typeof filtersGiven === 'object' && Object.keys(filtersGiven).length > 0 && !Array.isArray(filtersGiven))
-			filtersToLoop = [filtersGiven];
-		else if(filtersGiven !== undefined && Array.isArray(filtersGiven))
-			filtersToLoop = filtersGiven;
+		let parsedFilters = orCondition ? [] : {};
 
-		if(Array.isArray(filtersToLoop) && filtersToLoop.length > 0) {
+		// Only arrays as a filter
+		if(filters !== undefined && typeof filters === 'object' && Object.keys(filters).length > 0 && !Array.isArray(filters))
+			filters = [filters];
+
+		if(filters && Array.isArray(filters) && filters.length > 0) {
 			// First loop over all filters given by parameters
-			filtersToLoop.forEach(filterGiven => {
-				const formedFilter = MongoDBFilterWrapper.parseObjectFilter(filterGiven, modelFilters);
-
-				if(orCondition)
-					filtersArray.push(formedFilter);
-				else
-					filters = Object.assign(filters, formedFilter);
-
+			filters.forEach(filterGiven => {
+				const fullyParsedFilter = this.parseObjectFilter(filterGiven, modelFields);
+				parsedFilters = (orCondition && Array.isArray(parsedFilters))
+					? [...parsedFilters, fullyParsedFilter] : Object.assign(parsedFilters, fullyParsedFilter);
 			});
 		}
 
-		if(orCondition) {
+		if(orCondition && parsedFilters.length > 0) {
 			return {
-				$or: filtersArray
+				$or: parsedFilters
 			};
 		}
 
-		return filters;
+		return parsedFilters;
 	}
 
 	/**
 		* Parse the filter comparing given fields name and model fields
-		* @param filterComplete
-		* @param modelFilters
+		* @param filters Object Filters defined as parameters
+		* @param modelFields Object Model that will use the filter
+		* @return filterToResponse Object The filter parsed with all the values by one
 		*/
-	static parseObjectFilter(filterComplete, modelFilters) {
+	static parseObjectFilter(filters, modelFields) {
 		const filterToResponse = {};
 
-		// for(const col in filterComplete) {
-		for(const [col, value] of Object.entries(filterComplete)) {
-			const field = MongoDBFilterWrapper.getFieldToCompare(col, modelFilters);
+		for(const [field] of Object.entries(filters)) {
+			const fieldName = this.getFieldToCompare(field, modelFields);
 
-			if(typeof value === 'object')
-				filterToResponse[field] = MongoDBFilterWrapper.createFilter(col, value, modelFilters[col]);
-			else
-				filterToResponse[field] = MongoDBFilterWrapper.createFilter(col, { value }, modelFilters[col]);
+			const value = (typeof filters[field] !== 'object') ? { value: filters[field] } : filters[field];
+
+			filterToResponse[fieldName] = this.createFilter(value, modelFields[field]);
 		}
 		return filterToResponse;
 	}
 
 	/**
 		* Creates the object or the value(string/array) to use in the filter
-		* @param col
-		* @param filterToParse
-		* @param modelFilters
-		* @returns {string|{}}
+		* @returns {string|Object} Value to use in filter, with type or if is an equal only the value to
+		* search
+		* @param filter Object Filters defined as parameters
+		* @param modelFields Object Model that will use the filter
 		*/
-	static createFilter(col, filterToParse, modelFilters) {
-		const type = MongoDBFilterWrapper.getFilterType(filterToParse, modelFilters);
-		const value = MongoDBFilterWrapper.getValue(filterToParse);
+	static createFilter(filter, modelFields) {
+		const type = this.getFilterType(filter, modelFields);
+		const value = this.getValue(filter);
 
 		if(type === 'equal')
 			return value;
 
 		return {
-			[MongoDBFilterWrapper.filtersAllowed[type]]: value
+			[this.filtersAllowed[type]]: value
 		};
 	}
 
 	/**
-		* Gets the value to use in the filter, if is a object(suposse ID) transform to string
+		* Gets the value to use in the filter, if is a object(suppose ID) transform to string
 		* else search that exists the key value to return, or only returns an empty string
-		* @param filterToUse
-		* @returns {string}
+		* @returns value String With the value to filter
+		* @param filter Object With all the filter
 		*/
-	static getValue(filterToUse) {
-		let result = '';
+	static getValue(filter) {
+		let value = '';
 
-		if(typeof filterToUse === 'object' && filterToUse.value === undefined)
-			result = filterToUse.str;
+		if(typeof filter === 'object' && filter.value === undefined)
+			value = filter.str;
 
-		if(filterToUse.value !== undefined)
-			result = filterToUse.value;
+		if(filter.value !== undefined)
+			({ value } = filter);
 
-		return result;
+		return value;
 	}
 
 	/**
 		* Transforms the type given in the filter to a filter used in MongoDB
-		* @param filterComplete
-		* @param modelFilters
-		* @returns {string}
+		* @returns type string MongoDB type
+		* @param filter Object Filter by params to use
+		* @param modelField Object Model fields
 		*/
-	static getFilterType(filterComplete, modelFilters) {
+	static getFilterType(filter, modelField) {
 		let type = 'equal';
 
-		if(filterComplete && filterComplete.type !== undefined)
-			({ type } = filterComplete);
-		else if(modelFilters && modelFilters.type !== undefined)
-			({ type } = modelFilters);
+		if(filter && filter.type !== undefined)
+			({ type } = filter);
+		else if(modelField && modelField.type !== undefined)
+			({ type } = modelField);
 
 		return type;
 	}
@@ -152,12 +148,12 @@ class MongoDBFilterWrapper {
 	/**
 		* Returns the field to use in filter, if is defined in the Model returns
 		* the field setted, else returns the col given in the filter
-		* @param col
-		* @param modelFilters
-		* @returns {string|filters.field|{type, value}|string}
+		* @returns {string} Field to use in filter, if exists in Model returns it else will be used as it comes
+		* @param fieldName String Field defined in params
+		* @param modelField Object Model fields to compare key by fieldName
 		*/
-	static getFieldToCompare(col, modelFilters) {
-		return (modelFilters[col] && modelFilters[col].field) ? modelFilters[col].field : col;
+	static getFieldToCompare(fieldName, modelField) {
+		return (modelField[fieldName] && modelField[fieldName].field) ? modelField[fieldName].field : fieldName;
 	}
 }
 

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -18,29 +18,29 @@ class MongoDBFilterWrapper {
 
 	/**
 		* Enter door to filter process
-		* @param modelFields Object Model that will use the filter
-		* @param filters Object Filters defined as parameters
-		* @returns {{$or}|{}} Object with the filter parsed
+		* @param model {Object} Model that will use the filter
+		* @param filters {Object} Filters defined as parameters
+		* @returns {Object} with the filter parsed
 		*/
 	static process(model, filters) {
-		let modelFilters = {};
-
-		// Get model filters
-		if(model.constructor && model.constructor.fields)
-			modelFilters = model.constructor.fields;
+		let modelFields = {};
 
 		// Validate filters given
 		if(typeof filters !== 'object' || (Array.isArray(filters) && filters.length === 0) || Object.entries(filters).length === 0)
 			return {};
 
-		return this.getParsedFilters(filters, modelFilters);
+		// Get model filters
+		if(model.constructor && model.constructor.fields)
+			modelFields = model.constructor.fields || {};
+
+		return this.getParsedFilters(filters, modelFields);
 	}
 
 	/**
 		* Validates filters given and loop calling to parse
-		* @returns parsedFilters Array|Object The filter parsed to use in MongoDB
-		* @param filters Object Filters defined as parameters
-		* @param modelFields Object Model that will use the filter
+		* @param filters {Object} Filters defined as parameters
+		* @param modelFields {Object} Model that will use the filter
+		* @returns {Array|Object} The filter parsed to use in MongoDB
 		*/
 	static getParsedFilters(filters, modelFields) {
 		const orCondition = Array.isArray(filters);
@@ -71,9 +71,9 @@ class MongoDBFilterWrapper {
 
 	/**
 		* Parse the filter comparing given fields name and model fields
-		* @param filters Object Filters defined as parameters
-		* @param modelFields Object Model that will use the filter
-		* @return filterToResponse Object The filter parsed with all the values by one
+		* @param filters {Object} One filter given with her type and value(only uses that info)
+		* @param modelFields {Object} Model that will use the filter if exists
+		* @returns {Object} The filter parsed with all the values by one
 		*/
 	static parseObjectFilter(filters, modelFields) {
 		const filterToResponse = {};
@@ -81,7 +81,7 @@ class MongoDBFilterWrapper {
 		for(const [field, value] of Object.entries(filters)) {
 			const fieldName = this.getFieldToCompare(field, modelFields);
 
-			const filter = (typeof filters[field] !== 'object') ? { value } : value;
+			const filter = (typeof value !== 'object') ? { value } : value;
 
 			filterToResponse[fieldName] = this.createFilter(filter, modelFields[field]);
 		}
@@ -90,10 +90,10 @@ class MongoDBFilterWrapper {
 
 	/**
 		* Creates the object or the value(string/array) to use in the filter
+		* @param filter {Object} Filter given as parameter to parse with type and value
+		* @param modelFields {Object} Model field that will use the filter, if exists
 		* @returns {string|Object} Value to use in filter, with type or if is an equal only the value to
 		* search
-		* @param filter Object Filters defined as parameters
-		* @param modelFields Object Model that will use the filter
 		*/
 	static createFilter(filter, modelFields) {
 		const type = this.getFilterType(filter, modelFields);
@@ -110,8 +110,8 @@ class MongoDBFilterWrapper {
 	/**
 		* Gets the value to use in the filter, if is a object(suppose ID) transform to string
 		* else search that exists the key value to return, or only returns an empty string
-		* @returns value String With the value to filter
-		* @param filter Object With all the filter
+		* @param filter {Object} With all the filter
+		* @returns {string|number|object|array} With the value to filter
 		*/
 	static getValue(filter) {
 		let value = '';
@@ -127,9 +127,9 @@ class MongoDBFilterWrapper {
 
 	/**
 		* Transforms the type given in the filter to a filter used in MongoDB
-		* @returns type string MongoDB type
-		* @param filter Object Filter by params to use
-		* @param modelField Object Model fields
+		* @param filter {Object} Filter by params to use
+		* @param modelField {Object} Model fields
+		* @returns {string} MongoDB type
 		*/
 	static getFilterType(filter, modelField) {
 		let type = 'equal';
@@ -144,10 +144,10 @@ class MongoDBFilterWrapper {
 
 	/**
 		* Returns the field to use in filter, if is defined in the Model returns
-		* the field setted, else returns the col given in the filter
+		* the field set, else returns the col given in the filter
+		* @param fieldName {String} Field defined in params
+		* @param modelField {Object} Model fields to compare key by fieldName
 		* @returns {string} Field to use in filter, if exists in Model returns it else will be used as it comes
-		* @param fieldName String Field defined in params
-		* @param modelField Object Model fields to compare key by fieldName
 		*/
 	static getFieldToCompare(fieldName, modelField) {
 		return (modelField[fieldName] && modelField[fieldName].field) ? modelField[fieldName].field : fieldName;

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -43,10 +43,7 @@ class MongoDBFilterWrapper {
 		* @param modelFields Object Model that will use the filter
 		*/
 	static getParsedFilters(filters, modelFields) {
-		let orCondition = false;
-
-		if(Array.isArray(filters))
-			orCondition = true;
+		const orCondition = Array.isArray(filters);
 
 		let parsedFilters = orCondition ? [] : {};
 

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -1,0 +1,37 @@
+'use strict';
+
+class MongoDBFilterWrapper {
+	static get filtersAllowed() {
+		return {
+			notEqual: '$not',
+			greater: '$gt',
+			greaterOrEqual: '$gte',
+			lesser: '$lt',
+			lesserOrEqual: '$lte'
+		};
+	}
+
+	static process(model, filters) {
+		const filtersToReturn = {};
+		// eslint-disable-next-line guard-for-in,no-restricted-syntax
+		for(const aFilter in filters) {
+			const conditionFilter = (model.constructor && model.constructor.fields) ? model.constructor.fields[aFilter] : '';
+			if(conditionFilter && conditionFilter.type !== undefined) {
+				// MongoDBFilterWrapper.filtersAllowed.indexOf(aFilter);
+				const mongoCond = MongoDBFilterWrapper.filtersAllowed[conditionFilter.type];
+				if(mongoCond) {
+					const filterCol = conditionFilter.field ? conditionFilter.field : aFilter;
+					const aUse = {
+						[mongoCond]: filters[aFilter]
+					};
+					filtersToReturn[filterCol] = aUse;
+				}
+			}
+		}
+
+		return filtersToReturn;
+	}
+
+}
+
+module.exports = MongoDBFilterWrapper;

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -18,14 +18,14 @@ class MongoDBFilterWrapper {
 
 	/**
 		* Enter door to filter process
-		* @param model {Object} Model that will use the filter
-		* @param filters {Object} Filters defined as parameters
+		* @param {Object} model Model that will use the filter
+		* @param {Object} filters Filters defined as parameters
 		* @returns {Object} with the filter parsed
 		*/
 	static process(model, filters) {
 
 		// Validate filters given
-		if(typeof filters !== 'object' || (Array.isArray(filters) && filters.length === 0) || Object.entries(filters).length === 0)
+		if(typeof filters !== 'object' || (Array.isArray(filters) && !filters.length) || !Object.entries(filters).length)
 			return {};
 
 		// Get model filters
@@ -36,8 +36,8 @@ class MongoDBFilterWrapper {
 
 	/**
 		* Validates filters given and loop calling to parse
-		* @param filters {Object} Filters defined as parameters
-		* @param modelFields {Object} Model that will use the filter
+		* @param {Object} filters Filters defined as parameters
+		* @param {Object} modelFields Model that will use the filter
 		* @returns {Array|Object} The filter parsed to use in MongoDB
 		*/
 	static getParsedFilters(filters, modelFields) {
@@ -46,19 +46,19 @@ class MongoDBFilterWrapper {
 		let parsedFilters = orCondition ? [] : {};
 
 		// Only arrays as a filter
-		if(filters !== undefined && typeof filters === 'object' && Object.keys(filters).length > 0 && !Array.isArray(filters))
+		if(typeof filters === 'object' && !Array.isArray(filters) && Object.keys(filters).length)
 			filters = [filters];
 
-		if(filters && filters.length > 0) {
+		if(filters && filters.length) {
 			// First loop over all filters given by parameters
 			filters.forEach(filterGiven => {
 				const fullyParsedFilter = this.parseObjectFilter(filterGiven, modelFields);
-				parsedFilters = (orCondition && Array.isArray(parsedFilters))
+				parsedFilters = (orCondition)
 					? [...parsedFilters, fullyParsedFilter] : Object.assign(parsedFilters, fullyParsedFilter);
 			});
 		}
 
-		if(orCondition && parsedFilters.length > 0) {
+		if(orCondition && parsedFilters.length) {
 			return {
 				$or: parsedFilters
 			};
@@ -69,8 +69,8 @@ class MongoDBFilterWrapper {
 
 	/**
 		* Parse the filter comparing given fields name and model fields
-		* @param filters {Object} One filter given with her type and value(only uses that info)
-		* @param modelFields {Object} Model that will use the filter if exists
+		* @param {Object} filters One filter given with her type and value(only uses that info)
+		* @param {Object} modelFields Model that will use the filter if exists
 		* @returns {Object} The filter parsed with all the values by one
 		*/
 	static parseObjectFilter(filters, modelFields) {
@@ -88,8 +88,8 @@ class MongoDBFilterWrapper {
 
 	/**
 		* Creates the object or the value(string/array) to use in the filter
-		* @param filter {Object} Filter given as parameter to parse with type and value
-		* @param modelFields {Object} Model field that will use the filter, if exists
+		* @param {Object} filter Filter given as parameter to parse with type and value
+		* @param {Object} modelFields Model field that will use the filter, if exists
 		* @returns {string|Object} Value to use in filter, with type or if is an equal only the value to
 		* search
 		*/
@@ -97,7 +97,7 @@ class MongoDBFilterWrapper {
 		const type = this.getFilterType(filter, modelFields);
 		const value = this.getValue(filter);
 
-		if(type === 'equal')
+		if(type === 'equal' || !this.filtersAllowed[type])
 			return value;
 
 		return {
@@ -108,14 +108,14 @@ class MongoDBFilterWrapper {
 	/**
 		* Gets the value to use in the filter, if is a object(suppose ID) transform to string
 		* else search that exists the key value to return, or only returns an empty string
-		* @param filter {Object} With all the filter
+		* @param {Object} filter With all the filter
 		* @returns {string|number|object|array} With the value to filter
 		*/
 	static getValue(filter) {
 		let value = '';
 
 		if(typeof filter === 'object' && filter.value === undefined)
-			value = filter.str;
+			value = filter.toString();
 
 		if(filter.value !== undefined)
 			({ value } = filter);
@@ -125,8 +125,8 @@ class MongoDBFilterWrapper {
 
 	/**
 		* Transforms the type given in the filter to a filter used in MongoDB
-		* @param filter {Object} Filter by params to use
-		* @param modelField {Object} Model fields
+		* @param {Object} filter Filter by params to use
+		* @param {Object} modelField Model fields
 		* @returns {string} MongoDB type
 		*/
 	static getFilterType(filter, modelField) {
@@ -143,8 +143,8 @@ class MongoDBFilterWrapper {
 	/**
 		* Returns the field to use in filter, if is defined in the Model returns
 		* the field set, else returns the col given in the filter
-		* @param fieldName {String} Field defined in params
-		* @param modelField {Object} Model fields to compare key by fieldName
+		* @param {String} fieldName Field defined in params
+		* @param {Object} modelField Model fields to compare key by fieldName
 		* @returns {string} Field to use in filter, if exists in Model returns it else will be used as it comes
 		*/
 	static getFieldToCompare(fieldName, modelField) {

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -23,15 +23,13 @@ class MongoDBFilterWrapper {
 		* @returns {Object} with the filter parsed
 		*/
 	static process(model, filters) {
-		let modelFields = {};
 
 		// Validate filters given
 		if(typeof filters !== 'object' || (Array.isArray(filters) && filters.length === 0) || Object.entries(filters).length === 0)
 			return {};
 
 		// Get model filters
-		if(model.constructor && model.constructor.fields)
-			modelFields = model.constructor.fields || {};
+		const modelFields = model.constructor.fields || {};
 
 		return this.getParsedFilters(filters, modelFields);
 	}

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -22,15 +22,15 @@ class MongoDBFilterWrapper {
 		* @param filters Object Filters defined as parameters
 		* @returns {{$or}|{}} Object with the filter parsed
 		*/
-	static process(modelFields, filters) {
+	static process(model, filters) {
 		let modelFilters = {};
 
 		// Get model filters
-		if(modelFields.constructor && modelFields.constructor.fields)
-			modelFilters = modelFields.constructor.fields;
+		if(model.constructor && model.constructor.fields)
+			modelFilters = model.constructor.fields;
 
-		// Get model filters
-		if(typeof filters !== 'object' || filters.length === 0)
+		// Validate filters given
+		if(typeof filters !== 'object' || (Array.isArray(filters) && filters.length === 0) || Object.entries(filters).length === 0)
 			return {};
 
 		return this.getParsedFilters(filters, modelFilters);
@@ -54,7 +54,7 @@ class MongoDBFilterWrapper {
 		if(filters !== undefined && typeof filters === 'object' && Object.keys(filters).length > 0 && !Array.isArray(filters))
 			filters = [filters];
 
-		if(filters && Array.isArray(filters) && filters.length > 0) {
+		if(filters && filters.length > 0) {
 			// First loop over all filters given by parameters
 			filters.forEach(filterGiven => {
 				const fullyParsedFilter = this.parseObjectFilter(filterGiven, modelFields);

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -219,7 +219,12 @@ class MongoDB {
 				.toArray();
 
 			model.lastQueryEmpty = !res.length;
-			model.totalsParams = { ...params };
+			model.totalsParams = {
+				limit,
+				page,
+				filters,
+				order
+			};
 
 			return res.map(this.prepareFieldsForOutput);
 
@@ -540,7 +545,7 @@ class MongoDB {
 	/**
 	 * Multi remove items from the database
 	 * @param {Model} model Model instance
-	 * @param {filter} filter mongodb filter
+	 * @param {{filter: {value: {in: string[]}}}} filter mongodb filter
 	 * @returns {Number} deleted count
 	 */
 	async multiRemove(model, filter) {

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -545,7 +545,7 @@ class MongoDB {
 	/**
 	 * Multi remove items from the database
 	 * @param {Model} model Model instance
-	 * @param {{filter: {value: {in: string[]}}}} filter mongodb filter
+	 * @param {Object} filter mongodb filter
 	 * @returns {Number} deleted count
 	 */
 	async multiRemove(model, filter) {

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -10,6 +10,8 @@ const MongoDBError = require('./mongodb-error');
 
 const ConfigValidator = require('./config-validator');
 
+const MongoDBFilterWrapper = require('./mongodb-filter-wrapper');
+
 const DEFAULT_LIMIT = 500;
 
 const MONGODB_DEFAULT_PROTOCOL = 'mongodb://';
@@ -200,7 +202,7 @@ class MongoDB {
 
 		const page = params.page || 1;
 
-		const filters = params.filters || {};
+		const filters = MongoDBFilterWrapper.process(model, params.filters);
 
 		const order = params.order || { $natural: 1 };
 

--- a/tests/mongodb-dependencies/filter-wrapper-test.js
+++ b/tests/mongodb-dependencies/filter-wrapper-test.js
@@ -56,7 +56,8 @@ class Model {
 			store_dist: {
 				type: 'not',
 				field: 'store'
-			}
+			},
+			store_equal: 'AB'
 		};
 	}
 
@@ -91,20 +92,50 @@ describe('MongoDB', () => {
 		mockRequire.stopAll();
 	});
 
-	describe('filterWrapper', () => {
+	describe('Using FilterWrapper', () => {
+
 		it('should get an equal value if isnt defined type', async () => {
 			// Insert
-			const result = await mongodb.save(model, { id: 1, value: 'save_test_data' });
+			const result = await mongodb.save(model, { id: 1, store: 'Janis', gain: 10, bla: 'foo' });
 			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
-			const item = await mongodb.get(model, { filters: { value: 'save_test_data' } });
-			assert.deepStrictEqual(item[0].value, 'save_test_data');
-			// Update
-			/* result = await mongodb.save(model, { id: item[0].id, value: 'save_test_data_updated' });
-			assert.deepEqual(result, item[0].id.toString());
-			item = await mongodb.get(model, { filters: { id: item[0].id } });
-			assert.deepEqual(item[0].value, 'save_test_data_updated'); */
+			const item = await mongodb.get(model, { filters: { bla: 'foo', gain: 10 } });
+			assert.deepStrictEqual(item[0].store, 'Janis');
 			await clearMockedDatabase();
 		});
+
+		it('should get a value if is not defined a filter', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, store: 'Janis', gain: 10, bla: 'foo' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const item = await mongodb.get(model, { });
+			assert.deepStrictEqual(item[0].store, 'Janis');
+			await clearMockedDatabase();
+		});
+
+		it('should get an or filter if defined by an array', async () => {
+			// Insert
+			const result = await mongodb.save(model, {
+				id: 1,
+				store: 'Janis',
+				gain: 10,
+				bla: 'foo'
+			});
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const item = await mongodb.get(model, {
+				filters: [{
+					store: {
+						value: 'Janis',
+						type: 'not'
+					},
+					bla: 'afoo'
+				},
+				{
+					gain: 10
+				}]
+			});
+			assert.deepStrictEqual(item[0].store, 'Janis');
+		});
+
 
 		it('should get an gte date if isnt defined type', async () => {
 			// Insert
@@ -157,23 +188,83 @@ describe('MongoDB', () => {
 			await clearMockedDatabase();
 		});
 
-		/* it('should get an gte filter if isnt defined type', async () => {
+		it('should get an gte filter if isnt defined type', async () => {
 			// Insert
-			const result = await mongodb.save(model, { id: 1, date_from: '2000-01-03' });
+			const result = await mongodb.save(model, { id: 1, date: '2000-01-02', store: 'AAA' });
 			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
-			const item = await mongodb.get(model, { filters: { date_from: '2000-01-01' } });
-			assert.deepStrictEqual(item[0].date_from, '2000-01-03');
+			const result2 = await mongodb.save(model, { id: 2, date: '2000-01-05', store: 'AAA' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result2), true);
+			const result3 = await mongodb.save(model, { id: 3, date: '2000-01-10', store: 'AAA' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result3), true);
+			const item = await mongodb.get(model, { filters: { date: { value: '2000-01-10', type: 'lesser' }, store: 'AAA' } });
+			assert.deepStrictEqual([item[0].date, item[1].date], ['2000-01-02', '2000-01-05']);
 			await clearMockedDatabase();
-		});*/
+		});
 
-		/* it('should get an equal filter if isnt defined type', async () => {
+		it('should get an or filter if define a array', async () => {
 			// Insert
-			const result = await mongodb.save(model, { id: 1, value: 'save_test_data' });
-			assert.deepEqual(MongoDriver.ObjectID.isValid(result), true);
-			const item = await mongodb.get(model, { filters: { value: 'save_test_data', type: 'notEqual' } });
-			assert.deepEqual(item[0].value, '');
+			const result = await mongodb.save(model, { id: 1, store: 'save_test_data' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const result2 = await mongodb.save(model, { id: 2, store: 'only_for_test' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result2), true);
+			const result3 = await mongodb.save(model, { id: 3, store: 'foo_value' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result3), true);
+			const item = await mongodb.get(model, { filters: [{ store: 'save_test_data' }, { store: { value: 'foo_value', type: 'equal' } }] });
+			assert.deepStrictEqual([item[0].store, item[1].store], ['save_test_data', 'foo_value']);
 			await clearMockedDatabase();
-		});*/
-	});
+		});
 
+		it('should get values with an in filter if define a array to search', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, store: 'save_test_data' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const result2 = await mongodb.save(model, { id: 2, store: 'only_for_test' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result2), true);
+			const result3 = await mongodb.save(model, { id: 3, store: 'foo_value' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result3), true);
+			const item = await mongodb.get(model, { filters: { store: { value: ['save_test_data', 'foo_value'], type: 'in' } } });
+			assert.deepStrictEqual([item[0].store, item[1].store], ['save_test_data', 'foo_value']);
+			await clearMockedDatabase();
+		});
+
+		it('should get values with an in filter if define a array to search', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, store: 'save_test_data' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const result2 = await mongodb.save(model, { id: 2, store: 'only_for_test' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result2), true);
+			const result3 = await mongodb.save(model, { id: 3, store: 'foo_value' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result3), true);
+			const item = await mongodb.get(model, { filters: { store: { value: ['save_test_data', 'foo_value'], type: 'notIn' } } });
+			assert.deepStrictEqual([item[0].store], ['only_for_test']);
+			await clearMockedDatabase();
+		});
+
+		it('should get all values in a filter if define a array to search', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, store: ['save_test_data', 'blabla'] });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const result2 = await mongodb.save(model, { id: 2, store: ['blabla'] });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result2), true);
+			const result3 = await mongodb.save(model, { id: 3, store: 'foo_value' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result3), true);
+			const item = await mongodb.get(model, { filters: { store: { value: ['save_test_data', 'blabla'], type: 'all' } } });
+			assert.deepStrictEqual([item[0].store], [['save_test_data', 'blabla']]);
+			await clearMockedDatabase();
+		});
+
+		it('should get all values that accomplish one value of filter if define a array to search', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, store: ['save_test_data', 'blabla'] });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const result2 = await mongodb.save(model, { id: 2, store: ['blabla', 'new_foo_value'] });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result2), true);
+			const result3 = await mongodb.save(model, { id: 3, store: ['foo_value'] });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result3), true);
+			const item = await mongodb.get(model, { filters: { store: { value: ['blabla'], type: 'in' } } });
+			assert.deepStrictEqual(item.length, 2);
+			await clearMockedDatabase();
+		});
+
+	});
 });

--- a/tests/mongodb-dependencies/filter-wrapper-test.js
+++ b/tests/mongodb-dependencies/filter-wrapper-test.js
@@ -123,7 +123,7 @@ describe('MongoDB', () => {
 
 	describe('Using FilterWrapper with filters', () => {
 
-		it('should get an equal value if isnt defined type', async () => {
+		it('should get an equal value if isn\'t defined type', async () => {
 			collectionStub.toArray.returns([response]);
 			const item = await mongodb.get(model, { filters: { bla: 'foo', gain: 10 } });
 			assert.deepStrictEqual(item[0], response);

--- a/tests/mongodb-dependencies/filter-wrapper-test.js
+++ b/tests/mongodb-dependencies/filter-wrapper-test.js
@@ -1,0 +1,179 @@
+'use strict';
+
+// Clear node require caches
+Object.keys(require.cache).forEach(key => { delete require.cache[key]; });
+
+const assert = require('assert');
+const sandbox = require('sinon').createSandbox();
+const mockRequire = require('mock-require');
+const MongoDriver = require('mongodb');
+
+mockRequire('mongodb', 'mongo-mock');
+
+const MongoMock = require('mongodb');
+
+MongoMock.max_delay = 0; // Evitar lags en los tests
+
+const MongoDB = require('../../index');
+
+class Model {
+
+	static get uniqueIndexes() {
+		return [
+			'id',
+			'unique'
+		];
+	}
+
+	static get indexes() {
+		return [
+			'value'
+		];
+	}
+
+	static get table() {
+		return 'table';
+	}
+
+	static get fields() {
+		return {
+			date_from: {
+				type: 'greaterOrEqual',
+				field: 'date'
+			},
+			date_from2: {
+				type: 'greater',
+				field: 'date'
+			},
+			date_to: {
+				type: 'lesserOrEqual',
+				field: 'date'
+			},
+			date_to2: {
+				type: 'lesser',
+				field: 'date'
+			},
+			store_dist: {
+				type: 'not',
+				field: 'store'
+			}
+		};
+	}
+
+}
+
+const mongodb = new MongoDB({
+	host: 'localhost',
+	port: 27017,
+	database: 'myDB'
+});
+
+const model = new Model();
+
+const getCollection = async () => {
+	await mongodb.checkConnection();
+	return mongodb.client.db(mongodb.config.database)
+		.collection(model.constructor.table);
+};
+
+const clearMockedDatabase = async () => {
+	const collection = await getCollection();
+	await collection.drop();
+};
+
+describe('MongoDB', () => {
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	after(() => {
+		mockRequire.stopAll();
+	});
+
+	describe('filterWrapper', () => {
+		it('should get an equal value if isnt defined type', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, value: 'save_test_data' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const item = await mongodb.get(model, { filters: { value: 'save_test_data' } });
+			assert.deepStrictEqual(item[0].value, 'save_test_data');
+			// Update
+			/* result = await mongodb.save(model, { id: item[0].id, value: 'save_test_data_updated' });
+			assert.deepEqual(result, item[0].id.toString());
+			item = await mongodb.get(model, { filters: { id: item[0].id } });
+			assert.deepEqual(item[0].value, 'save_test_data_updated'); */
+			await clearMockedDatabase();
+		});
+
+		it('should get an gte date if isnt defined type', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, date: '2000-01-03' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const item = await mongodb.get(model, { filters: { date_from: '2000-01-01' } });
+			assert.deepStrictEqual(item[0].date, '2000-01-03');
+			await clearMockedDatabase();
+		});
+
+		it('should get an gt date if define a field with that filter', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, date: '2000-01-01' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const result1 = await mongodb.save(model, { id: 2, date: '2000-01-02' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result1), true);
+			const result2 = await mongodb.save(model, { id: 3, date: '2000-01-03' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result2), true);
+			const item = await mongodb.get(model, { filters: { date_from2: '2000-01-01' } });
+			assert.deepStrictEqual([item[0].date, item[1].date], ['2000-01-02', '2000-01-03']);
+			await clearMockedDatabase();
+		});
+
+		it('should get an lte filter if is defined that filter', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, date: '2000-01-25' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const item = await mongodb.get(model, { filters: { date_to: '2000-01-25' } });
+			assert.deepStrictEqual(item[0].date, '2000-01-25');
+			await clearMockedDatabase();
+		});
+
+		it('should get an lt date if is defined that filter', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, date: '2000-01-25' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const result1 = await mongodb.save(model, { id: 2, date: '2000-01-02' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result1), true);
+			const item = await mongodb.get(model, { filters: { date_to2: '2000-01-25' } });
+			assert.deepStrictEqual(item[0].date, '2000-01-02');
+			await clearMockedDatabase();
+		});
+
+		it('should get a value if filter is distinct', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, store: 'ASTORE' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const item = await mongodb.get(model, { filters: { store_dist: 'JBA1' } });
+			assert.deepStrictEqual(item[0].store, 'ASTORE');
+			await clearMockedDatabase();
+		});
+
+		/* it('should get an gte filter if isnt defined type', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, date_from: '2000-01-03' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
+			const item = await mongodb.get(model, { filters: { date_from: '2000-01-01' } });
+			assert.deepStrictEqual(item[0].date_from, '2000-01-03');
+			await clearMockedDatabase();
+		});*/
+
+		/* it('should get an equal filter if isnt defined type', async () => {
+			// Insert
+			const result = await mongodb.save(model, { id: 1, value: 'save_test_data' });
+			assert.deepEqual(MongoDriver.ObjectID.isValid(result), true);
+			const item = await mongodb.get(model, { filters: { value: 'save_test_data', type: 'notEqual' } });
+			assert.deepEqual(item[0].value, '');
+			await clearMockedDatabase();
+		});*/
+	});
+
+});

--- a/tests/mongodb-test.js
+++ b/tests/mongodb-test.js
@@ -82,7 +82,7 @@ describe('MongoDB', () => {
 				result = newMongo.config;
 			});
 
-			assert.deepEqual(result.port, 27017);
+			assert.deepStrictEqual(result.port, 27017);
 
 		});
 	});
@@ -133,11 +133,11 @@ describe('MongoDB', () => {
 	describe('formatIndex()', () => {
 
 		it('should return a formatted index object when recieves an array as parameter', async () => {
-			assert.deepEqual(mongodb.formatIndex(['foo', 'bar']), { foo: 1, bar: 1 });
+			assert.deepStrictEqual(mongodb.formatIndex(['foo', 'bar']), { foo: 1, bar: 1 });
 		});
 
 		it('should return formatted index object when recieves a string as parameter', () => {
-			assert.deepEqual(mongodb.formatIndex('foo'), { foo: 1 });
+			assert.deepStrictEqual(mongodb.formatIndex('foo'), { foo: 1 });
 		});
 	});
 
@@ -159,7 +159,7 @@ describe('MongoDB', () => {
 			});
 
 			await assert.doesNotReject(mongodb.createIndexes(model));
-			assert.deepEqual(createIndex.called, true);
+			assert.deepStrictEqual(createIndex.called, true);
 		});
 
 		it('should not reject when create indexes without indexes in the model', async () => {
@@ -171,7 +171,7 @@ describe('MongoDB', () => {
 			});
 
 			await assert.doesNotReject(mongodb.createIndexes(model));
-			assert.deepEqual(createIndex.called, true);
+			assert.deepStrictEqual(createIndex.called, true);
 		});
 
 		it('should not reject when create indexes with indexes and unique indexes in the model', async () => {
@@ -180,7 +180,7 @@ describe('MongoDB', () => {
 
 			await assert.doesNotReject(mongodb.createIndexes(model));
 
-			assert.deepEqual(createIndex.called, true);
+			assert.deepStrictEqual(createIndex.called, true);
 		});
 
 		it('should reject when try to create indexes with an invalid model', async () => {
@@ -215,9 +215,9 @@ describe('MongoDB', () => {
 
 			mongodb.prepareFields(fields);
 
-			assert.deepEqual(typeof fields.id, 'undefined');
+			assert.deepStrictEqual(typeof fields.id, 'undefined');
 
-			assert.deepEqual(fields._id, ObjID);
+			assert.deepStrictEqual(fields._id, ObjID);
 		});
 
 		it('should replace the \'id\' field with \'_id\' when \'id\' exists and is an array', () => {
@@ -230,9 +230,9 @@ describe('MongoDB', () => {
 
 			mongodb.prepareFields(fields);
 
-			assert.deepEqual(typeof fields.id, 'undefined');
+			assert.deepStrictEqual(typeof fields.id, 'undefined');
 
-			assert.deepEqual(fields._id, [ObjID]);
+			assert.deepStrictEqual(fields._id, [ObjID]);
 		});
 
 		it('should replace the \'id\' field with \'_id\' when \'id\' exists for filters', () => {
@@ -245,9 +245,9 @@ describe('MongoDB', () => {
 
 			mongodb.prepareFields(fields, true);
 
-			assert.deepEqual(typeof fields.id, 'undefined');
+			assert.deepStrictEqual(typeof fields.id, 'undefined');
 
-			assert.deepEqual(fields._id, ObjID);
+			assert.deepStrictEqual(fields._id, ObjID);
 		});
 
 		it('should replace the \'id\' field with \'_id\' when \'id\' exists and is an array for filters', () => {
@@ -260,9 +260,9 @@ describe('MongoDB', () => {
 
 			mongodb.prepareFields(fields, true);
 
-			assert.deepEqual(typeof fields.id, 'undefined');
+			assert.deepStrictEqual(typeof fields.id, 'undefined');
 
-			assert.deepEqual(fields._id, { $in: [ObjID] });
+			assert.deepStrictEqual(fields._id, { $in: [ObjID] });
 		});
 
 		it('should do nothing when the \'_id\' exists and \'id\' not exists', () => {
@@ -275,9 +275,9 @@ describe('MongoDB', () => {
 
 			mongodb.prepareFields(fields);
 
-			assert.deepEqual(typeof fields.id, 'undefined');
+			assert.deepStrictEqual(typeof fields.id, 'undefined');
 
-			assert.deepEqual(fields._id, ObjID);
+			assert.deepStrictEqual(fields._id, ObjID);
 		});
 	});
 
@@ -293,9 +293,9 @@ describe('MongoDB', () => {
 
 			mongodb.prepareFieldsForOutput(fields);
 
-			assert.deepEqual(typeof fields._id, 'undefined');
+			assert.deepStrictEqual(typeof fields._id, 'undefined');
 
-			assert.deepEqual(fields.id, ObjID);
+			assert.deepStrictEqual(fields.id, ObjID);
 		});
 	});
 
@@ -309,14 +309,14 @@ describe('MongoDB', () => {
 
 			const result = mongodb.getFilter(model, { id: 1 });
 
-			assert.deepEqual(result.id, 1);
+			assert.deepStrictEqual(result.id, 1);
 		});
 
 		it('should return non empty filter object when get filters with an object as parameter', () => {
 
 			const result = mongodb.getFilter(model, { id: 1 });
 
-			assert.deepEqual(result.id, 1);
+			assert.deepStrictEqual(result.id, 1);
 		});
 
 		it('should throw when get filters with a model without unique indexes', () => {
@@ -386,7 +386,7 @@ describe('MongoDB', () => {
 
 			const result = await mongodb.get(model, { order: { id: 'asc' } });
 
-			assert.deepEqual(result[0].value, 'get_test_data');
+			assert.deepStrictEqual(result[0].value, 'get_test_data');
 
 			await clearMockedDatabase();
 		});
@@ -415,16 +415,15 @@ describe('MongoDB', () => {
 
 		it('should upsert an item when save an unexisting and existing item', async () => {
 			// Insert
-			let result = await mongodb.save(model, { id: 1, value: 'save_test_data' });
-			assert.deepEqual(MongoDriver.ObjectID.isValid(result), true);
+			let result = await mongodb.save(model, { id: '5d5476783cb30600068170df', value: 'save_test_data' });
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
 			let item = await mongodb.get(model, { filters: { value: 'save_test_data' } });
-			assert.deepEqual(item[0].value, 'save_test_data');
+			assert.deepStrictEqual(item[0].value, 'save_test_data');
 			// Update
 			result = await mongodb.save(model, { id: item[0].id, value: 'save_test_data_updated' });
-			assert.deepEqual(result, item[0].id.toString());
+			assert.deepStrictEqual(result, item[0].id.toString());
 			item = await mongodb.get(model, { filters: { id: item[0].id } });
-			assert.deepEqual(item[0].value, 'save_test_data_updated');
-
+			assert.deepStrictEqual(item[0].value, 'save_test_data_updated');
 			await clearMockedDatabase();
 		});
 
@@ -436,7 +435,7 @@ describe('MongoDB', () => {
 			sandbox.stub(collection, 'updateOne').returns({ matchedCount: 1, modifiedCount: 1 });
 
 			const result = await mongodb.save(model, { id: itemSaved.id, value: 'save_test_data_updated' });
-			assert.deepEqual(result, itemSaved.id);
+			assert.deepStrictEqual(result, itemSaved.id);
 
 		});
 
@@ -446,25 +445,25 @@ describe('MongoDB', () => {
 
 			// Insert
 			let result = await mongodb.save(model, itemToSave);
-			assert.deepEqual(MongoDriver.ObjectID.isValid(result), true);
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
 
 			const itemSaved = await mongodb.get(model, { filters: { value: itemToSave.value } });
-			assert.deepEqual(itemSaved[0].value, itemToSave.value);
-			assert.deepEqual(itemSaved[0].unique, itemToSave.unique);
+			assert.deepStrictEqual(itemSaved[0].value, itemToSave.value);
+			assert.deepStrictEqual(itemSaved[0].unique, itemToSave.unique);
 
 			const itemToUpdate = { unique: itemToSave.unique, value: 'save_test_data_updated' };
 
 			// Update
 			result = await mongodb.save(model, itemToUpdate);
-			assert.deepEqual(result, itemToUpdate.unique);
+			assert.deepStrictEqual(result, itemToUpdate.unique);
 
 			const itemUpdated = await mongodb.get(model, { filters: { value: itemToUpdate.value } });
-			assert.deepEqual(itemUpdated[0].value, itemToUpdate.value);
-			assert.deepEqual(itemUpdated[0].unique, itemToUpdate.unique);
+			assert.deepStrictEqual(itemUpdated[0].value, itemToUpdate.value);
+			assert.deepStrictEqual(itemUpdated[0].unique, itemToUpdate.unique);
 
 			// Should be the same
-			assert.deepEqual(itemUpdated[0].unique, itemSaved[0].unique);
-			assert.deepEqual(itemUpdated[0].id, itemSaved[0].id);
+			assert.deepStrictEqual(itemUpdated[0].unique, itemSaved[0].unique);
+			assert.deepStrictEqual(itemUpdated[0].id, itemSaved[0].id);
 
 			await clearMockedDatabase();
 
@@ -474,7 +473,7 @@ describe('MongoDB', () => {
 
 			const result = await mongodb.save(model, { id: undefined, value: 'save_test_data' });
 
-			assert.deepEqual(MongoDriver.ObjectID.isValid(result), true);
+			assert.deepStrictEqual(MongoDriver.ObjectID.isValid(result), true);
 			await clearMockedDatabase();
 		});
 
@@ -506,11 +505,11 @@ describe('MongoDB', () => {
 
 			const result = await mongodb.update(model, { value: 'update_test_data_updated' }, { value: 'update_test_data' });
 
-			assert.deepEqual(result, 1);
+			assert.deepStrictEqual(result, 1);
 
 			const item = await mongodb.get(model, { value: 'update_test_data_updated' });
 
-			assert.deepEqual(item[0].value, 'update_test_data_updated');
+			assert.deepStrictEqual(item[0].value, 'update_test_data_updated');
 
 			await clearMockedDatabase();
 		});
@@ -547,11 +546,11 @@ describe('MongoDB', () => {
 
 			const result = await mongodb.multiInsert(model, items);
 
-			assert.deepEqual(result, true);
+			assert.deepStrictEqual(result, true);
 
 			items = await mongodb.get(model, { filters: { value: 'multiInsert_test_data' } });
 
-			assert.deepEqual(items.length, 3);
+			assert.deepStrictEqual(items.length, 3);
 
 			await clearMockedDatabase();
 		});
@@ -617,14 +616,14 @@ describe('MongoDB', () => {
 
 			const result = await mongodb.multiSave(model, items);
 
-			assert.deepEqual(result, true);
+			assert.deepStrictEqual(result, true);
 		});
 
 		it('should return false when try to multi save without items', async () => {
 
 			const result = await mongodb.multiSave(model, []);
 
-			assert.deepEqual(result, false);
+			assert.deepStrictEqual(result, false);
 		});
 
 		it('should throw when any of the save stacks rejects', async () => {
@@ -677,14 +676,14 @@ describe('MongoDB', () => {
 
 			const result = await mongodb.remove(model, { id: item[0].id });
 
-			assert.deepEqual(result, true);
+			assert.deepStrictEqual(result, true);
 		});
 
 		it('should return false when can\'t remove the item', async () => {
 
 			const result = await mongodb.remove(model, { id: 1 });
 
-			assert.deepEqual(result, false);
+			assert.deepStrictEqual(result, false);
 		});
 
 		it('should reject when try to remove an item with an invalid model', async () => {
@@ -761,11 +760,11 @@ describe('MongoDB', () => {
 				return { deletedCount: 0 };
 			});
 
-			await mongodb.multiInsert(model, [{ value: 'deleteThis' }, { value: 'deleteThis2' }]);
+			await mongodb.multiInsert(model, [{ store: 'deleteThis' }, { store: 'deleteThis2' }]);
 
-			const result = await mongodb.multiRemove(model, { value: { $in: ['deleteThis', 'deleteThis2'] } });
+			const result = await mongodb.multiRemove(model, { filter: { store: { value: ['deleteThis', 'deleteThis2'], type: 'in' } } });
 
-			assert.deepEqual(result, 2);
+			assert.deepStrictEqual(result, 2);
 
 			await clearMockedDatabase();
 		});
@@ -803,15 +802,15 @@ describe('MongoDB', () => {
 				.map((item, i) => {
 					return {
 						id: i,
-						value: `get_totals_test ${i}`
+						field: `get_totals_test ${i}`
 					};
 				});
 
 			await mongodb.multiInsert(model, inserts);
 
-			await mongodb.get(model, { limit: 5, page: 1, filters: { value: /get_totals_test/ } });
+			await mongodb.get(model, { limit: 5, page: 1, filters: { field: { value: /get_totals_test/, type: 'reg' } } });
 
-			assert.deepEqual(await mongodb.getTotals(model), {
+			assert.deepStrictEqual(await mongodb.getTotals(model), {
 				total: 10,
 				pageSize: 5,
 				pages: 2,
@@ -834,7 +833,7 @@ describe('MongoDB', () => {
 				page: 100
 			};
 
-			assert.deepEqual(await mongodb.getTotals(model), {
+			assert.deepStrictEqual(await mongodb.getTotals(model), {
 				total: 100,
 				pageSize: 10,
 				pages: 10,
@@ -850,7 +849,7 @@ describe('MongoDB', () => {
 				return 100;
 			});
 
-			assert.deepEqual(await mongodb.getTotals(model), {
+			assert.deepStrictEqual(await mongodb.getTotals(model), {
 				total: 100,
 				pageSize: 500,
 				pages: 1,
@@ -860,7 +859,7 @@ describe('MongoDB', () => {
 
 		it('should return zero totals when get the totals with a last empty query in the model', async () => {
 			model.lastQueryEmpty = true;
-			assert.deepEqual(await mongodb.getTotals(model), {
+			assert.deepStrictEqual(await mongodb.getTotals(model), {
 				total: 0,
 				pages: 0
 			});

--- a/tests/mongodb-test.js
+++ b/tests/mongodb-test.js
@@ -762,7 +762,7 @@ describe('MongoDB', () => {
 
 			await mongodb.multiInsert(model, [{ store: 'deleteThis' }, { store: 'deleteThis2' }]);
 
-			const result = await mongodb.multiRemove(model, { filter: { store: { value: ['deleteThis', 'deleteThis2'], type: 'in' } } });
+			const result = await mongodb.multiRemove(model, { store: { value: ['deleteThis', 'deleteThis2'], type: 'in' } });
 
 			assert.deepStrictEqual(result, 2);
 


### PR DESCRIPTION
Link al ticket

[Escenario #5: Agregar mapeo de filtros para método get](https://fizzmod.atlassian.net/browse/JCN-160)

Descripción del requerimiento
Se agrega el filtro para obtener datos desde Mongo seteando con la misma idea que Query Builder

Descripción de la solución
Se definieron filtros dentro de Filter Wrapper para que reconozca filtros diferentes al 'equal' y se reconocen desde params y los que existen en Model.

Cómo se puede probar?
Probar con los diferentes tipos de filtros para obtener diferentes respuestas.

Screenshots


Necesita deployear queries?
No

Datos extra a tener en cuenta
Si se tiene duda de la estructura verlo en el Readme.md o sino en los tests hay ejemplos.