### PR TITLE
JCN-164-nuevos-filtros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `filter-wrapper` Module
 - Model filter handling
+- `search` filter support
+- nested filters documentation
+### Fixed
+- `notEqual` filter type
 
 ## [1.4.0] - 2019-09-12
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Parameters example:
    }
 }
 ```
-##### Filters
+#### Filters
 
 The filters has a structure to apply, by default uses `equal`.
 For example:
@@ -141,19 +141,32 @@ If you want to apply different filters it should be as follows:
 }
 ```
 
+#### Nested filters
+Also you can use nested filters, for example:
+```js
+{
+   filters: {
+      'aField.property':{
+         value: 'valueToFilter', // required(string or array)
+         type: 'aTypeChoosen' //optional
+      }
+   }
+}
+```
+
 The possible types to use are:
 
 | Filter        | Mongo filter          |
 |---------------|-----------------------|
 | equal         | $eq                   |
-| not           | $ne                   |
+| notEqual      | $ne                   |
 | greater       | $gt                   |
 | greaterOrEqual| $gte                  |
 | lesser        | $lt                   |
 | lesserOrEqual | $lte                  |
 | in            | $in                   |
 | notIn         | $nin                  |
-| reg           | $reg                  |
+| search        | $regex                |
 | all           | $all                  |
 
 

--- a/README.md
+++ b/README.md
@@ -142,13 +142,23 @@ If you want to apply different filters it should be as follows:
 ```
 
 #### Nested filters
-Also you can use nested filters, for example:
+If you want to filter by fields inside objects, you can use nested filters. For example:
 ```js
 {
+
+   /* item example
+   {
+      id: 'some-id',
+      aField: {
+         property: 'foobar'
+      }
+   }
+   */
+
    filters: {
       'aField.property':{
-         value: 'valueToFilter', // required(string or array)
-         type: 'aTypeChoosen' //optional
+         value: 'foobar', // required(string or array)
+         type: 'equal' //optional
       }
    }
 }

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -4,14 +4,14 @@ class MongoDBFilterWrapper {
 	static get filtersAllowed() {
 		return {
 			equal: '$eq',
-			not: '$ne',
+			notEqual: '$ne',
 			greater: '$gt',
 			greaterOrEqual: '$gte',
 			lesser: '$lt',
 			lesserOrEqual: '$lte',
 			in: '$in',
 			notIn: '$nin',
-			reg: '$regex',
+			search: '$regex',
 			all: '$all'
 		};
 	}

--- a/tests/mongodb-dependencies/filter-wrapper-test.js
+++ b/tests/mongodb-dependencies/filter-wrapper-test.js
@@ -51,7 +51,7 @@ class Model {
 				field: 'date'
 			},
 			store_dist: {
-				type: 'not',
+				type: 'notEqual',
 				field: 'store'
 			},
 			store_equal: 'AB'
@@ -156,7 +156,7 @@ describe('MongoDB', () => {
 				{
 					store: {
 						value: 'Janis',
-						type: 'not'
+						type: 'notEqual'
 					},
 					bla: 'afoo'
 				},


### PR DESCRIPTION
**JCN-164-NUEVOS-FILTROS**
JCN-164 Nuevos tipos de filtro de texto y búsqueda dentro de un objeto

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-164

**DESCRIPCIÓN DEL REQUERIMIENTO**
6.1. Agregar el tipo de filtro de texto, el mismo debe funcionar cómo el search del package Query-Builder (https://github.com/janis-commerce/query-builder/blob/master/docs/Filters.md)
6.2. Agregar la posiblidad de buscar dentro de un object.
6.2.1. Se debe poder enviar el filtro en modo object.
6.2.2. Se deben poder utilizar todos los tipos de filtros conocidos.
6.2.3. Ej. en caso de enviar filters: { foo.bar: 2 } se debería buscar en por los registros que en el dato bar igual a 2 dentro de foo.
6.2.4. Ej. en caso de enviar filters: { dates.created: { type: 'greater', value: '10/10/2019' } } se debe poder buscar los registros que dentro del campo dates, el campo created sea mayor al valor 10/10/2019

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se realizaron los requerimientos solicitados