### PR TITLE
Adding filter manipulation if exists another.-

### DIFF
--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -68,21 +68,6 @@ class MongoDBFilterWrapper {
 	}
 
 	/**
-		* Validates if exists another field and merge with and condition
-		* @param {Object} filter One filter or object given
-		* @param {Object} modelField Model field that use in filters
-		* @param {Object} filterToResponse Filter that will be returned
-		* @return {string|Object} Filter created or merged object
-		*/
-	static createFilter(filter, modelField, filterToResponse) {
-
-		if(modelField && modelField.field && filterToResponse[modelField.field])
-			return { ...this.generateFilter(filter, modelField), ...filterToResponse[modelField.field] };
-
-		return this.generateFilter(filter, modelField);
-	}
-
-	/**
 		* Parse the filter comparing given fields name and model fields
 		* @param {Object} filters One filter given with her type and value(only uses that info)
 		* @param {Object} modelFields Model that will use the filter if exists
@@ -99,6 +84,33 @@ class MongoDBFilterWrapper {
 			filterToResponse[fieldName] = this.createFilter(filter, modelFields[field], filterToResponse);
 		}
 		return filterToResponse;
+	}
+
+
+	/**
+		 * Returns the field to use in filter, if is defined in the Model returns
+		 * the field set, else returns the col given in the filter
+		 * @param {String} fieldName Field defined in params
+		 * @param {Object} modelField Model fields to compare key by fieldName
+		 * @returns {string} Field to use in filter, if exists in Model returns it else will be used as it comes
+		 */
+	static getFieldToCompare(fieldName, modelField) {
+		return (modelField[fieldName] && modelField[fieldName].field) ? modelField[fieldName].field : fieldName;
+	}
+
+	/**
+		 * Validates if exists another field and merge with and condition
+		 * @param {Object} filter One filter or object given
+		 * @param {Object} modelField Model field that use in filters
+		 * @param {Object} filterToResponse Filter that will be returned
+		 * @return {string|Object} Filter created or merged object
+		 */
+	static createFilter(filter, modelField, filterToResponse) {
+
+		if(modelField && modelField.field && filterToResponse[modelField.field])
+			return { ...this.generateFilter(filter, modelField), ...filterToResponse[modelField.field] };
+
+		return this.generateFilter(filter, modelField);
 	}
 
 	/**
@@ -121,6 +133,23 @@ class MongoDBFilterWrapper {
 	}
 
 	/**
+		 * Transforms the type given in the filter to a filter used in MongoDB
+		 * @param {Object} filter Filter by params to use
+		 * @param {Object} modelField Model fields
+		 * @returns {string} MongoDB type
+		 */
+	static getFilterType(filter, modelField) {
+		let type = 'equal';
+
+		if(filter && filter.type !== undefined)
+			({ type } = filter);
+		else if(modelField && modelField.type !== undefined)
+			({ type } = modelField);
+
+		return type;
+	}
+
+	/**
 		* Gets the value to use in the filter, if is a object(suppose ID) transform to string
 		* else search that exists the key value to return, or only returns an empty string
 		* @param {Object} filter With all the filter
@@ -136,34 +165,6 @@ class MongoDBFilterWrapper {
 			({ value } = filter);
 
 		return value;
-	}
-
-	/**
-		* Transforms the type given in the filter to a filter used in MongoDB
-		* @param {Object} filter Filter by params to use
-		* @param {Object} modelField Model fields
-		* @returns {string} MongoDB type
-		*/
-	static getFilterType(filter, modelField) {
-		let type = 'equal';
-
-		if(filter && filter.type !== undefined)
-			({ type } = filter);
-		else if(modelField && modelField.type !== undefined)
-			({ type } = modelField);
-
-		return type;
-	}
-
-	/**
-		* Returns the field to use in filter, if is defined in the Model returns
-		* the field set, else returns the col given in the filter
-		* @param {String} fieldName Field defined in params
-		* @param {Object} modelField Model fields to compare key by fieldName
-		* @returns {string} Field to use in filter, if exists in Model returns it else will be used as it comes
-		*/
-	static getFieldToCompare(fieldName, modelField) {
-		return (modelField[fieldName] && modelField[fieldName].field) ? modelField[fieldName].field : fieldName;
 	}
 }
 

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -68,6 +68,23 @@ class MongoDBFilterWrapper {
 	}
 
 	/**
+		* Validates if exists another field and merge with and condition
+		* @param {Object} filter One filter or object given
+		* @param {Object} modelField Model field that use in filters
+		* @param {Object} filterToResponse Filter that will be returned
+		* @return {string|Object} Filter created or merged object
+		*/
+	static createObjectFilter(filter, modelField, filterToResponse) {
+
+		let filterGenerated = this.createFilter(filter, modelField);
+
+		if(modelField && modelField.field && filterToResponse[modelField.field])
+			filterGenerated = Object.assign(filterGenerated, filterToResponse[modelField.field]);
+
+		return filterGenerated;
+	}
+
+	/**
 		* Parse the filter comparing given fields name and model fields
 		* @param {Object} filters One filter given with her type and value(only uses that info)
 		* @param {Object} modelFields Model that will use the filter if exists
@@ -81,7 +98,7 @@ class MongoDBFilterWrapper {
 
 			const filter = (typeof value !== 'object') ? { value } : value;
 
-			filterToResponse[fieldName] = this.createFilter(filter, modelFields[field]);
+			filterToResponse[fieldName] = this.createObjectFilter(filter, modelFields[field], filterToResponse);
 		}
 		return filterToResponse;
 	}

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -74,14 +74,12 @@ class MongoDBFilterWrapper {
 		* @param {Object} filterToResponse Filter that will be returned
 		* @return {string|Object} Filter created or merged object
 		*/
-	static createObjectFilter(filter, modelField, filterToResponse) {
-
-		let filterGenerated = this.createFilter(filter, modelField);
+	static createFilter(filter, modelField, filterToResponse) {
 
 		if(modelField && modelField.field && filterToResponse[modelField.field])
-			filterGenerated = Object.assign(filterGenerated, filterToResponse[modelField.field]);
+			return { ...this.generateFilter(filter, modelField), ...filterToResponse[modelField.field] };
 
-		return filterGenerated;
+		return this.generateFilter(filter, modelField);
 	}
 
 	/**
@@ -98,7 +96,7 @@ class MongoDBFilterWrapper {
 
 			const filter = (typeof value !== 'object') ? { value } : value;
 
-			filterToResponse[fieldName] = this.createObjectFilter(filter, modelFields[field], filterToResponse);
+			filterToResponse[fieldName] = this.createFilter(filter, modelFields[field], filterToResponse);
 		}
 		return filterToResponse;
 	}
@@ -110,7 +108,7 @@ class MongoDBFilterWrapper {
 		* @returns {string|Object} Value to use in filter, with type or if is an equal only the value to
 		* search
 		*/
-	static createFilter(filter, modelFields) {
+	static generateFilter(filter, modelFields) {
 		const type = this.getFilterType(filter, modelFields);
 		const value = this.getValue(filter);
 

--- a/lib/mongodb-filter-wrapper.js
+++ b/lib/mongodb-filter-wrapper.js
@@ -54,7 +54,7 @@ class MongoDBFilterWrapper {
 			filters.forEach(filterGiven => {
 				const fullyParsedFilter = this.parseObjectFilter(filterGiven, modelFields);
 				parsedFilters = (orCondition)
-					? [...parsedFilters, fullyParsedFilter] : Object.assign(parsedFilters, fullyParsedFilter);
+					? [...parsedFilters, fullyParsedFilter] : { ...parsedFilters, ...fullyParsedFilter };
 			});
 		}
 

--- a/tests/mongodb-dependencies/filter-wrapper-test.js
+++ b/tests/mongodb-dependencies/filter-wrapper-test.js
@@ -260,12 +260,19 @@ describe('MongoDB', () => {
 		});
 
 		it('should get all values that accomplish one value of filter if define a array to search', async () => {
-			// Insert
 			const resultIn = [{ id: 1, store: ['save_test_data', 'blabla'] }, { id: 2, store: ['blabla', 'new_foo_value'] }];
 			collectionStub.toArray.returns(resultIn);
 			const item = await mongodb.get(model, { filters: { store: { value: ['blabla'], type: 'in' } } });
 			assert.deepStrictEqual(item.length, 2);
 			sandbox.assert.calledWithExactly(collectionStub.find, { store: { $in: ['blabla'] } });
+		});
+
+		it('should get between values that accomplish the two filters if define as an and', async () => {
+			const resultIn = [{ id: 1, store: 'blabla', date: '2019-07-20' }, { id: 2, date: '2019-08-20', store: 'blabla' }];
+			collectionStub.toArray.returns(resultIn);
+			const item = await mongodb.get(model, { filters: { date_from: '2019-08-10', date_to: '2019-09-09' } });
+			assert.deepStrictEqual(item.length, 2);
+			sandbox.assert.calledWithExactly(collectionStub.find, { date: { $lte: '2019-09-09', $gte: '2019-08-10' } });
 		});
 
 	});


### PR DESCRIPTION
JCN-170 Permitir multiple filtro para el mismo campo de la base

LINK AL TICKET
https://fizzmod.atlassian.net/browse/JCN-170

DESCRIPCIÓN DEL REQUERIMIENTO
7.1. Se requiere dar soporte a multiples filtros aplicados para el mismo campo
7.2. Se deben agrupar los filtros cuando los tipos sean distintos.
7.3. Ej de uso esperado:
En el modelo se encontrarán los fields:
static get fields() {
	return {
		dateFrom: { field: 'date', type: 'greaterOrEqual' },
		dateTo: { field: 'date', type: 'lesserOrEqual' }
	};
}
Se podría llamará al filtro con:
const items = await myModel.get({
	filters: { dateFrom: '01/10/2019', dateTo: '05/10/2019' }
});
En mongodb deberíamos poder filtrar con:

await db.collection('table').find({
		date: { '$gte': '01/10/2019', '$lte': '05/10/2019' }
	});

DESCRIPCIÓN DE LA SOLUCIÓN
Se agregó esa manipulación 