### PR TITLE
fix the multi remove prepare filters

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -589,7 +589,7 @@ class MongoDB {
 
 		await this.checkConnection();
 
-		this.prepareFields(filter);
+		this.prepareFields(filter, true);
 
 		try {
 			const res = await this.db.collection(model.constructor.table)


### PR DESCRIPTION
**Link al ticket**
https://fizzmod.atlassian.net/browse/JAN-774

**Descripción del requerimiento**
Se requiere corregir el llamado al metodo `prepareFields` para que se preparen filtros, ya que cuando se envía el filtro id no se están borrando los documentos.

**Descripción de la solución**
Se pasa un `toFilter` en `true` para que cuando se hace el `prepareFields` se preparen filtros y en este caso se agrege lo requerido para que filtre los documentos y los elimine.

**Cómo se puede probar?**
Hacer `multiRemove` pasando como filtro:

- Un id `{ id: .... }`

- Un listado de ids {id: [...]}

- Un status o alguna otra propiedad que no sea en particular un id.

**Screenshots**
No.

**Datos extra a tener en cuenta**
No.

**Changelog**
Fixed: pass to filter flag when prepare fields on multiRemove method