### PR TITLE
JCN-Quick-Fixed-Save-return-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- `save` uses `findAndModify` with `upsert: true` and `new: true`, to return always `_id`
+
 ## [1.7.1] - 2019-11-22
 ### Fixed
 - `multiRemove` can remove multiple docs based on their IDs

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ getTotals return example:
 ### ***async*** `save(model, {item})`
 Insert/update a item into the database.
 Requires a `model [Model]` and `item [Object]`.
-Returns `String` **ID** of the item *inserted* or **Unique Index** used as filter if it was *updated* or rejects if cannot.
+Returns `String` **ID** of the item inserted or updated.
 
 ### ***async*** `multiSave(model, [{items}], limit)`
 Insert/update multiple items into the database.
@@ -343,9 +343,16 @@ mongo.createIndexes(model);
       }
    */
 
-   // save
+  // save insert
    result = await mongo.save(model, {
-      id: 1,
+      unique: 1,
+      value: 'sarasa'
+   }); // expected return: '00000058faf66849077316ba'
+
+   // save update
+   result = await mongo.save(model, {
+      id: '00000058faf66849077316ba',
+      unique: 1,
       value: 'sarasa'
    }); // expected return: '00000058faf66849077316ba'
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -330,7 +330,7 @@ class MongoDB {
 	 * Insert/update one element into the database
 	 * @param {Model} model Model instance
 	 * @param {Object} item item
-	 * @returns {String} inserted ID / updated unique index used as filter
+	 * @returns {String} ID
 	 */
 	async save(model, item = {}) {
 
@@ -350,21 +350,18 @@ class MongoDB {
 		this.cleanFields(item);
 
 		try {
+
 			const res = await this.db.collection(model.constructor.table)
-				.updateOne(filter, {
+				.findAndModify(filter, {}, {
 					$set: item,
 					$currentDate: { dateModified: true },
 					$setOnInsert: { dateCreated: new Date() }
-				}, { upsert: true });
+				}, { upsert: true, new: true });
 
-			const upsertId = res.upsertedId ? res.upsertedId._id : res.upsertedId; // If the object was Inserted: Get the ID
-
-			// If the object was Updated, it used the filter which always is one of the unique Indexes
-			const [uniqueIndexFilter] =	Object.values(filter);
-
-			return (upsertId || uniqueIndexFilter).toString();
+			return res && res.value && res.value._id.toString();
 
 		} catch(err) {
+
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}


### PR DESCRIPTION
**LINK AL TICKET**
- QUICK
​
**DESCRIPCIÓN DEL REQUERIMIENTO**
* Modificar método `save` para que devuelva el `_id` tanto al insertar como al actualizar
​
**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados, cambiando el uso de `updateOne` por `findAndModify`.