### PR TITLE
JCN 219 agregar set on insert en save multi save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `setOnInsert` param in `save` and `multiSave`
+
 ## [1.9.0] - 2020-01-13
 ### Added
 - `increment` method

--- a/README.md
+++ b/README.md
@@ -298,20 +298,22 @@ Return example:
 
 If no query was executed before, it will just return the `total` and `pages` properties with a value of zero.
 
-### ***async*** `save(model, item)`
+### ***async*** `save(model, item, setOnInsert)`
 Inserts or updates a document in a collection.
 - model: `Model`: A model instance used for the query.
 - item: `Object`: The item to upsert in the collection
+- setOnInsert: `Object`: Default values to insert on Items.
 
 - Resolves `Object`: An object containing the totalizers
 - Rejects `Error` When something bad occurs
 
 This operation uses unique indexes in order to update existing documents. If `id` is provided in the item, it will be used. Otherwise, it will try to match a unique index defined in the model. If no unique index can be matched by the item, it will reject an error.
 
-### ***async*** `multiSave(model, items)`
+### ***async*** `multiSave(model, items, setOnInsert)`
 Inserts or updates a document in a collection.
 - model: `Model`: A model instance used for the query.
 - items: `Array<Object>`: The items to upsert in the collection
+- setOnInsert: `Object`: Default values to insert on Items.
 
 - Resolves `Boolean`: `true` if items can be upserted
 - Rejects `Error` When something bad occurs
@@ -410,11 +412,7 @@ The codes are the following:
 | 6    | Invalid item format received       |
 | 7    | Invalid distinct key received      |
 | 8    | Filter type not recognized         |
-<<<<<<< HEAD
-| 9    | Invalid Increment Data             |
-=======
 | 9    | Invalid index structure            |
->>>>>>> JCN-metodos-indices
 
 ## Usage
 
@@ -491,6 +489,23 @@ const model = new Model();
       name: 'test'
    });
    // > '00000058faf66849077316ba'
+
+   // save update
+   result = await mongo.save(model, {
+      unique: 2,
+      name: 'test-2'
+   }, { status: 'active' });
+   // > '00000058faf66849077316bb'
+   // In DB : { _id: '00000058faf66849077316bb', unique: 2, name: 'test-2', dateCreated: ISODate("2020-01-14T14:01:29.170Z"), status: 'active' }
+
+   // save update
+   result = await mongo.save(model, {
+      unique: 2,
+      name: 'test-2',
+      status: 'inactive'
+   }, { status: 'active' });
+   // > '00000058faf66849077316bb'
+   // In DB : { _id: '00000058faf66849077316bb', unique: 2, name: 'test-2', dateCreated: ISODate("2020-01-14T14:01:29.170Z"), status: 'inactive' }
 
    // multiSave
    result = await mongo.multiSave(model, [

--- a/README.md
+++ b/README.md
@@ -412,7 +412,8 @@ The codes are the following:
 | 6    | Invalid item format received       |
 | 7    | Invalid distinct key received      |
 | 8    | Filter type not recognized         |
-| 9    | Invalid index structure            |
+| 9    | Invalid Increment Data             |
+| 10   | Invalid index structure            |
 
 ## Usage
 

--- a/lib/helpers/set-on-insert-parser.js
+++ b/lib/helpers/set-on-insert-parser.js
@@ -1,0 +1,25 @@
+'use strict';
+
+class SetOnInsertParser {
+
+	/**
+     * Parse Default values to avoid conflict with Set Data
+     * @param {Object} setOnInsert Default Values
+     * @param {Object} setData Data to Set
+     * @returns {Object} Default Values without Set Data fields
+     */
+	static parse(setOnInsert, setData) {
+
+		if(!setOnInsert)
+			return {};
+
+		return Object.entries(setOnInsert)
+			.reduce((acum, [field, value]) => {
+				if(typeof setData[field] === 'undefined')
+					acum = { ...acum, [field]: value };
+				return acum;
+			}, {});
+	}
+}
+
+module.exports = SetOnInsertParser;

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -12,6 +12,7 @@ const ObjectIdHelper = require('./helpers/object-id');
 const MongoDBSort = require('./helpers/sort');
 const UniqueMatcher = require('./helpers/unique-matcher');
 const IndexesHelper = require('./helpers/indexes');
+const SetOnInsertParser = require('./helpers/set-on-insert-parser');
 
 const ConfigValidator = require('./config-validator');
 const IncrementValidator = require('./helpers/increment-validator');
@@ -116,9 +117,10 @@ class MongoDB {
 	 * Insert/update one element into the database
 	 * @param {Model} model Model instance
 	 * @param {Object} item item
+	 * @param {Object} setOnInsert Default Values for Insert items
 	 * @returns {String} ID
 	 */
-	async save(model, item) {
+	async save(model, item, setOnInsert) {
 
 		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
@@ -131,11 +133,13 @@ class MongoDB {
 
 			const { _id, dateCreated, dateModified, ...setData } = mongoItem; // Remove to prevent upsert errors
 
+			const defaults = SetOnInsertParser.parse(setOnInsert, setData); // Remove to prevent upsert errors using default values
+
 			const res = await this.mongo.makeQuery(model, collection => collection
 				.findAndModify(filters, {}, {
 					$set: setData,
 					$currentDate: { dateModified: true },
-					$setOnInsert: { dateCreated: new Date() }
+					$setOnInsert: { dateCreated: new Date(), ...defaults }
 				}, { upsert: true, new: true }));
 
 			return res && res.value && res.value._id.toString();
@@ -244,10 +248,10 @@ class MongoDB {
 	 * Multi insert/update items into the dabatase
 	 * @param {Model} model Model instance
 	 * @param {Array} items items
-	 * @param {Number} limit specifies the limit of items that can be bulk writed into monogdb at the same time
+	 * @param {Object} setOnInsert Default Values for Insert items
 	 * @returns {Boolean} true/false
 	 */
-	async multiSave(model, items) {
+	async multiSave(model, items, setOnInsert) {
 
 		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
@@ -266,10 +270,12 @@ class MongoDB {
 
 			const { _id, dateCreated, dateModified, ...setData } = mongoItem; // Remove to prevent upsert errors
 
+			const defaults = SetOnInsertParser.parse(setOnInsert, setData); // Remove to prevent upsert errors using default values
+
 			const updateData = {
 				$set: setData,
 				$currentDate: { dateModified: true },
-				$setOnInsert: { dateCreated: new Date() }
+				$setOnInsert: { dateCreated: new Date(), ...defaults }
 			};
 
 			return { updateOne: { filter: filters, update: updateData, upsert: true } };


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-219
​
**DESCRIPCIÓN DEL REQUERIMIENTO**
Se requiere realizar las siguientes modificaciones

- Modificar los métodos `save()` y` multiSave() `para aceptar un parámetro object `setOnInsert`.
- Este objecto opcional debe agregarse en `$setOnInsert`.
- En caso de existir algún campo en la información de cada item, se debe eliminar de` setOnInsert`
​

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados