### PR TITLE
JCN 222 MultiInsert devuelve IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- `MultiInsert` returns Array with Items inserted
+
 ## [1.10.0] - 2020-01-14
 ### Added
 - `setOnInsert` param in `save` and `multiSave`

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Inserts multiple documents in a collection
 - model: `Model`: A model instance
 - item: `Array<Object>`: The items to save in the collection
 
-- Resolves `Boolean`: Indicating if the operation was successful.
+- Resolves `Array<Object>`: Items inserted
 - Rejects `Error` When something bad occurs
 
 ### ***async*** `update(model, values, filter)`

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -237,9 +237,10 @@ class MongoDB {
 			const res = await this.mongo.makeQuery(model, collection => collection
 				.insertMany(mongoItems));
 
-			return !!res.result.ok;
+			return res.ops.map(item => ObjectIdHelper.mapIdForClient(item));
 
 		} catch(err) {
+			console.log(err);
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -240,7 +240,6 @@ class MongoDB {
 			return res.ops.map(item => ObjectIdHelper.mapIdForClient(item));
 
 		} catch(err) {
-			console.log(err);
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -1071,7 +1071,19 @@ describe('MongoDB', () => {
 				name: 'Some name'
 			};
 
-			const insertMany = sinon.stub().resolves({ result: { ok: 1 } });
+			const expectedItem = {
+				otherId: ObjectID('5df0151dbc1d570011949d87'),
+				name: 'Some name',
+				dateCreated: sinon.match.date
+			};
+
+			const insertMany = sinon.stub().resolves({
+				result: { ok: 1 },
+				ops: [{
+					...expectedItem,
+					_id: ObjectID('5df0151dbc1d570011949d86')
+				}]
+			});
 
 			const collection = stubMongo(true, { insertMany });
 
@@ -1082,16 +1094,13 @@ describe('MongoDB', () => {
 				}
 			}), [{ ...item }]);
 
-			assert.deepStrictEqual(result, true);
+			assert.deepStrictEqual(result, [{
+				...expectedItem,
+				id: '5df0151dbc1d570011949d86'
+			}]);
 
 			sinon.assert.calledOnce(collection);
 			sinon.assert.calledWithExactly(collection, 'myCollection');
-
-			const expectedItem = {
-				otherId: ObjectID('5df0151dbc1d570011949d87'),
-				name: 'Some name',
-				dateCreated: sinon.match.date
-			};
 
 			sinon.assert.calledOnce(insertMany);
 			sinon.assert.calledWithExactly(insertMany, [expectedItem]);


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/
​
**DESCRIPCIÓN DEL REQUERIMIENTO**
Se requiere devolver los ids de los documentos insertados en mongo cuando se utiliza el método `multiInsert()`

Para hacer esto, se deberá devolver el campo ops que contiene el el array de  items agregándole el `id` y `dateCreated`

Utilizar `ObjectIdHelper.mapIdForClient(`) para devolver los ids correctamente.
​
**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados