### PR TITLE
JCN 322 Soportar el parámetro options en el método update de mongo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Changed
 - `update` Method now supports the options parameter.
 
 ## [1.16.1] - 2021-02-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `update` Method now supports the options parameter.
+
 ## [1.16.1] - 2021-02-08
 ### Changed
 - `getIndexes` method now returns the whole index without any format

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # MongoDB
 
 ![Build Status](https://github.com/janis-commerce/mongodb/workflows/Build%20Status/badge.svg)
@@ -99,7 +100,7 @@ await mongo.multiInsert(model, [
 
 </details>
 
-### ***async*** `update(model, values, filter)`
+### ***async*** `update(model, values, filter, options)`
 
 <details>
 <summary>Updates one or more documents in a collection</summary>
@@ -107,6 +108,7 @@ await mongo.multiInsert(model, [
 - model: `Model`: A model instance
 - values: `Object`: The values to set in the documents
 - filter: `Object`: Filter criteria to match documents
+- options: `Object`: Optional parameters of the query [See more](https://docs.mongodb.com/v3.6/reference/method/db.collection.updateMany/#definition)
 
 - Resolves `Number`: The number of modified documents
 - Rejects `Error` When something bad occurs
@@ -127,6 +129,27 @@ await mongo.update(
    { status: 'active' }, // the values to update
 );
 // > Number
+
+// Updating certain elements of an array
+/* Sample document to match
+{
+	_id: ObjectID('5df0151dbc1d570011949d86'),
+	items: [{ name: 'foo', price: 90 },{ name: 'bar', price: 45 }]
+}
+*/
+await mongo.update(
+   model,
+   { $set: { "items.$[elem].price" : 100 } }, // the values to update
+   {}
+   { arrayFilters: [ { "elem.price": { $gte: 85 } } ] }
+)
+// > Number
+/* Output
+{
+	_id: ObjectID('5df0151dbc1d570011949d86'),
+	items: [{ name: 'foo', price: 90 },{ name: 'bar', price: 100 }]
+}
+*/
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ await mongo.multiInsert(model, [
 - model: `Model`: A model instance
 - values: `Object`: The values to set in the documents
 - filter: `Object`: Filter criteria to match documents
-- options: `Object`: Optional parameters of the query [See more](https://docs.mongodb.com/v3.6/reference/method/db.collection.updateMany/#definition)
+- options: `Object`: Optional parameters (such as [arrayFilters](https://docs.mongodb.com/v3.6/release-notes/3.6/#arrayfilters)) of the query [See more](https://docs.mongodb.com/v3.6/reference/method/db.collection.updateMany/#definition)
 
 - Resolves `Number`: The number of modified documents
 - Rejects `Error` When something bad occurs
@@ -147,7 +147,7 @@ await mongo.update(
 /* Output
 {
 	_id: ObjectID('5df0151dbc1d570011949d86'),
-	items: [{ name: 'foo', price: 90 },{ name: 'bar', price: 100 }]
+	items: [{ name: 'foo', price: 100 },{ name: 'bar', price: 45 }]
 }
 */
 ```

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -183,9 +183,10 @@ class MongoDB {
 	 * @param {Model} model Model instance
 	 * @param {Object} values values to apply
 	 * @param {Object} filters mongodb filters
+	 * @param {Object} options mongodb options
 	 * @returns {Number} modified count
 	 */
-	async update(model, values, filters) {
+	async update(model, values, filters, options) {
 
 		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
@@ -205,7 +206,7 @@ class MongoDB {
 				}), {});
 
 			const res = await this.mongo.makeQuery(model, collection => collection
-				.updateMany(MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filters || {}), model), updateData));
+				.updateMany(MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filters || {}), model), updateData, options || {}));
 
 			return res.modifiedCount;
 

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -982,6 +982,8 @@ describe('MongoDB', () => {
 				}
 			};
 
+			const options = { upsert: true };
+
 			const updateMany = sinon.stub().resolves({ modifiedCount: 1 });
 
 			const collection = stubMongo(true, { updateMany });
@@ -991,7 +993,7 @@ describe('MongoDB', () => {
 				otherId: {
 					isID: true
 				}
-			}), { ...item }, { id });
+			}), { ...item }, { id }, options);
 
 			assert.deepStrictEqual(result, 1);
 
@@ -1019,7 +1021,7 @@ describe('MongoDB', () => {
 				_id: {
 					$eq: ObjectID(id)
 				}
-			}, expectedItem);
+			}, expectedItem, options);
 		});
 	});
 


### PR DESCRIPTION
### **LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-321

### **DESCRIPCIÓN DEL REQUERIMIENTO**
Se requiere soportar la funcionalidad del **arrayFilters** en el método **update** del package de mongo.

Se debe agregar al método la posibilidad de recibir el parámetro **options** de mongodb para soportar todas las funcionalidades. Ver documentación: https://docs.mongodb.com/v3.6/reference/method/db.collection.updateMany/

### **DESCRIPCIÓN DE LA SOLUCIÓN**
- Se modifico el método **update** para soportar el parámetro **options**.
- Se modificaron los test.
- Se modifico el **README** y el **CHANGELOG**.