### PR TITLE
Jcn 355 subtarea sumar configuracion para evitar cerrar conexiones mongo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Added new validation to close connections through `CLOSE_MONGODB_CONNECTIONS` environment variable value.
+- The deprecated `ObjectID` was changed to `ObjectId`.
 
 ## [2.0.2] - 2022-02-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added new validation to close connections through `CLOSE_MONGODB_CONNECTIONS` environment variable value.
 
 ## [2.0.2] - 2022-02-03
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Connections will be closed according to `CLOSE_MONGODB_CONNECTIONS` environment 
 
 | Value | Close connection | Remarks |
 |-------|------------------|---------|
-| `undefined` | :white_check_mark: | Is equivalent to nonexistent and is the default behavior |
-| `'false'` | :x: |  |
-| `1`, `'true'`, etc... | :white_check_mark: | any other value different from the above |
+| `undefined` (no value set) | :white_check_mark: | **Default behavior**, if you not set any value or create the env variable. |
+| `'false'` or `false` | :x: | :warning: Can be `false` or `'false'` because env variables are saved as string |
+| `1`, `'true'`, etc (any value set) | :white_check_mark: | Any other value different from the above. :warning:  We recommend to use `true` or no set any value |
 
 Connection will be closed by emitting a `janiscommerce.ended` event. The event will be emitted in the end of `janiscommerce` functions.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,15 @@ Now we are using [mongodb](https://www.npmjs.com/package/mongodb) `^4.3.1` drive
 
 ### Events and closing connections
 
-Connections will be closed when the event `janiscommerce.ended` was emitted. The event `janiscommerce.ended` will be emitted in the end of `janiscommerce` functions.
+Connections will be closed according to `CLOSE_MONGODB_CONNECTIONS` environment variable value:
+
+| Value | Close connection |
+|-------|------------------|
+| `not exist` | :white_check_mark: |
+| `false` | :x: |
+| `exists with any other value` | :white_check_mark: |
+
+The connection is closed through the event `janiscommerce.ended`. The event `janiscommerce.ended` will be emitted in the end of `janiscommerce` functions.
 
 For more information see [@janiscommerce/events](https://www.npmjs.com/package/@janiscommerce/events).
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Now we are using [mongodb](https://www.npmjs.com/package/mongodb) `^4.3.1` drive
 ### Events and closing connections
 
 To close connections, it is optional to define the environment variable `CLOSE_MONGODB_CONNECTIONS` in `Serverless.js` file.
-
 Connections will be closed according to `CLOSE_MONGODB_CONNECTIONS` environment variable value:
 
 | Value | Close connection |

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Now we are using [mongodb](https://www.npmjs.com/package/mongodb) `^4.3.1` drive
 
 ### Events and closing connections
 
-To close connections, it is optional to define the environment variable `CLOSE_MONGODB_CONNECTIONS` in `Serverless.js` file.
+To close connections, it is optional to define the environment variable `CLOSE_MONGODB_CONNECTIONS`.
 Connections will be closed according to `CLOSE_MONGODB_CONNECTIONS` environment variable value:
 
-| Value | Close connection |
-|-------|------------------|
-| `not exist` | :white_check_mark: |
-| `false` | :x: |
-| `exists with any other value` | :white_check_mark: |
+| Value | Close connection | Remarks |
+|-------|------------------|---------|
+| `undefined` | :white_check_mark: | Is equivalent to nonexistent and is the default behavior |
+| `'false'` | :x: |  |
+| `1`, `'true'`, etc... | :white_check_mark: | any other value different from the above |
 
 Connection will be closed by emitting a `janiscommerce.ended` event. The event will be emitted in the end of `janiscommerce` functions.
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Connections will be closed according to `CLOSE_MONGODB_CONNECTIONS` environment 
 | Value | Close connection | Remarks |
 |-------|------------------|---------|
 | `undefined` (no value set) | :white_check_mark: | **Default behavior**, if you not set any value or create the env variable. |
-| `'false'` or `false` | :x: | :warning: Can be `false` or `'false'` because env variables are saved as string |
-| `1`, `'true'`, etc (any value set) | :white_check_mark: | Any other value different from the above. :warning:  We recommend to use `true` or no set any value |
+| `'false'` or `false` | :x: | :warning: Can be `false` or `'false'` because env variables are saved as string. |
+| `1`, `'true'`, etc (any value set) | :white_check_mark: | Any other value different from the above. :warning:  We recommend to use `true` or no set any value. |
 
 Connection will be closed by emitting a `janiscommerce.ended` event. The event will be emitted in the end of `janiscommerce` functions.
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ class MyModel extends Model {
 }
 ```
 
-**Mongo ObjectIDs**
+**Mongo ObjectIds**
 
 The fields of type `ObjectId` can be defined in the model this way:
 ```js
@@ -308,7 +308,7 @@ class MyModel extends Model {
 }
 ```
 
-The package will handle the `string` to `ObjectID` conversion automatically for you. The `id` field is also automatically mapped to `_id` and converted to an `ObjectID`
+The package will handle the `string` to `ObjectId` conversion automatically for you. The `id` field is also automatically mapped to `_id` and converted to an `ObjectId`
 
 It also maps `_id` field to `id` when retrieving documents.
 
@@ -354,10 +354,10 @@ mongodb.get(myModel, {
 // This is converted to the following mongo filter:
 {
 	id: {
-		$eq: ObjectID('5df0151dbc1d570011949d86') // Automatically converted to ObjectID, default $eq type
+		$eq: ObjectId('5df0151dbc1d570011949d86') // Automatically converted to ObjectId, default $eq type
 	},
 	otherIdField: {
-		$in: [ObjectID('5df0151dbc1d570011949d87'), ObjectID('5df0151dbc1d570011949d88')] // Converted to ObjectID by model, default $in type
+		$in: [ObjectId('5df0151dbc1d570011949d87'), ObjectId('5df0151dbc1d570011949d88')] // Converted to ObjectId by model, default $in type
 	},
 	greaterField: {
 		$gte: 15 // $gte type defined by model

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Now we are using [mongodb](https://www.npmjs.com/package/mongodb) `^4.3.1` drive
 
 ### Events and closing connections
 
+To close connections, it is optional to define the environment variable `CLOSE_MONGODB_CONNECTIONS` in `Serverless.js` file.
+
 Connections will be closed according to `CLOSE_MONGODB_CONNECTIONS` environment variable value:
 
 | Value | Close connection |
@@ -27,7 +29,7 @@ Connections will be closed according to `CLOSE_MONGODB_CONNECTIONS` environment 
 | `false` | :x: |
 | `exists with any other value` | :white_check_mark: |
 
-The connection is closed through the event `janiscommerce.ended`. The event `janiscommerce.ended` will be emitted in the end of `janiscommerce` functions.
+Connection will be closed by emitting a `janiscommerce.ended` event. The event will be emitted in the end of `janiscommerce` functions.
 
 For more information see [@janiscommerce/events](https://www.npmjs.com/package/@janiscommerce/events).
 

--- a/lib/helpers/object-id.js
+++ b/lib/helpers/object-id.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const { ObjectID } = require('../mongodb-wrapper');
+const { ObjectId } = require('../mongodb-wrapper');
 
 /**
  * @typedef {import('mongodb').Document} MongoDocument
  */
 
-const ensureObjectId = id => (typeof id === 'string' ? ObjectID(id) : id);
+const ensureObjectId = id => (typeof id === 'string' ? ObjectId(id) : id);
 
 module.exports = class ObjectIdHelper {
 

--- a/lib/mongodb-filters.js
+++ b/lib/mongodb-filters.js
@@ -3,7 +3,7 @@
 const { inspect } = require('util');
 
 const MongoDBError = require('./mongodb-error');
-const { ObjectID } = require('./mongodb-wrapper');
+const { ObjectId } = require('./mongodb-wrapper');
 
 module.exports = class MongoDBFilters {
 
@@ -130,9 +130,9 @@ module.exports = class MongoDBFilters {
 	 * Map a value (or array of values) to Mongo Object IDs
 	 *
 	 * @param {string|array<string>} value The id(s) as string(s)
-	 * @return {ObjectID|array<ObjectID>} The id(s) as ObjectID(s)
+	 * @return {ObjectId|array<ObjectId>} The id(s) as ObjectId(s)
 	 */
 	static mapToObjectId(value) {
-		return Array.isArray(value) ? value.map(v => ObjectID(v)) : ObjectID(value);
+		return Array.isArray(value) ? value.map(v => ObjectId(v)) : ObjectId(value);
 	}
 };

--- a/lib/mongodb-wrapper.js
+++ b/lib/mongodb-wrapper.js
@@ -105,9 +105,7 @@ module.exports.MongoWrapper = class MongoWrapper {
 	}
 
 	shouldCloseConnection() {
-
-		if(process.env.CLOSE_MONGODB_CONNECTIONS !== 'false')
-			return true;
+		return process.env.CLOSE_MONGODB_CONNECTIONS !== 'false';
 	}
 
 	closeConnections() {

--- a/lib/mongodb-wrapper.js
+++ b/lib/mongodb-wrapper.js
@@ -64,7 +64,7 @@ module.exports.MongoWrapper = class MongoWrapper {
 		};
 	}
 
-	get closeConnection() {
+	get shouldCloseConnection() {
 		return process.env.CLOSE_MONGODB_CONNECTIONS;
 	}
 
@@ -86,14 +86,13 @@ module.exports.MongoWrapper = class MongoWrapper {
 				try {
 					clients[dbConfigKey] = await this.connect(config);
 
-					if(this.closeConnection !== 'false')
+					if(this.shouldCloseConnection !== 'false')
 						Events.once('janiscommerce.ended', this.closeConnections);
 
 				} catch(err) {
 					throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 				}
 			}
-
 
 			if(!dbs[dbConfigKey])
 				dbs[dbConfigKey] = {};

--- a/lib/mongodb-wrapper.js
+++ b/lib/mongodb-wrapper.js
@@ -82,7 +82,9 @@ module.exports.MongoWrapper = class MongoWrapper {
 				try {
 					clients[dbConfigKey] = await this.connect(config);
 
-					Events.once('janiscommerce.ended', this.closeConnections);
+					// opcion 1
+					if(this.CLOSE_MONGODB_CONNECTIONS !== false)
+						Events.once('janiscommerce.ended', this.closeConnections);
 
 				} catch(err) {
 					throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
@@ -104,13 +106,18 @@ module.exports.MongoWrapper = class MongoWrapper {
 	}
 
 	closeConnections() {
-		Object.entries(clients).forEach(([configKey, client]) => {
 
-			client.close();
+		// opcion 2
+		if(this.CLOSE_MONGODB_CONNECTIONS !== false) {
 
-			delete clients[configKey];
-			delete dbs[configKey];
-		});
+			Object.entries(clients).forEach(([configKey, client]) => {
+
+				client.close();
+
+				delete clients[configKey];
+				delete dbs[configKey];
+			});
+		}
 	}
 
 	/**

--- a/lib/mongodb-wrapper.js
+++ b/lib/mongodb-wrapper.js
@@ -64,6 +64,10 @@ module.exports.MongoWrapper = class MongoWrapper {
 		};
 	}
 
+	get closeConnection() {
+		return process.env.CLOSE_MONGODB_CONNECTIONS;
+	}
+
 	/**
 	 * Checks that a valid connection is set, and set's it otherwise
 	 *
@@ -82,14 +86,14 @@ module.exports.MongoWrapper = class MongoWrapper {
 				try {
 					clients[dbConfigKey] = await this.connect(config);
 
-					// opcion 1
-					if(this.CLOSE_MONGODB_CONNECTIONS !== false)
+					if(this.closeConnection !== 'false')
 						Events.once('janiscommerce.ended', this.closeConnections);
 
 				} catch(err) {
 					throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 				}
 			}
+
 
 			if(!dbs[dbConfigKey])
 				dbs[dbConfigKey] = {};
@@ -107,17 +111,13 @@ module.exports.MongoWrapper = class MongoWrapper {
 
 	closeConnections() {
 
-		// opcion 2
-		if(this.CLOSE_MONGODB_CONNECTIONS !== false) {
+		Object.entries(clients).forEach(([configKey, client]) => {
 
-			Object.entries(clients).forEach(([configKey, client]) => {
+			client.close();
 
-				client.close();
-
-				delete clients[configKey];
-				delete dbs[configKey];
-			});
-		}
+			delete clients[configKey];
+			delete dbs[configKey];
+		});
 	}
 
 	/**

--- a/lib/mongodb-wrapper.js
+++ b/lib/mongodb-wrapper.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { MongoClient, ObjectID } = require('mongodb');
+const { MongoClient, ObjectId } = require('mongodb');
 
 const Events = require('@janiscommerce/events');
 
@@ -19,7 +19,7 @@ const dbs = {};
  * @returns {T}
  */
 
-module.exports.ObjectID = ObjectID;
+module.exports.ObjectId = ObjectId;
 
 module.exports.MongoWrapper = class MongoWrapper {
 

--- a/lib/mongodb-wrapper.js
+++ b/lib/mongodb-wrapper.js
@@ -64,10 +64,6 @@ module.exports.MongoWrapper = class MongoWrapper {
 		};
 	}
 
-	get shouldCloseConnection() {
-		return process.env.CLOSE_MONGODB_CONNECTIONS;
-	}
-
 	/**
 	 * Checks that a valid connection is set, and set's it otherwise
 	 *
@@ -86,7 +82,7 @@ module.exports.MongoWrapper = class MongoWrapper {
 				try {
 					clients[dbConfigKey] = await this.connect(config);
 
-					if(this.shouldCloseConnection !== 'false')
+					if(this.shouldCloseConnection())
 						Events.once('janiscommerce.ended', this.closeConnections);
 
 				} catch(err) {
@@ -106,6 +102,12 @@ module.exports.MongoWrapper = class MongoWrapper {
 	connect() {
 		const mongoClient = new MongoClient(this.connectionString, this.connectionParams);
 		return mongoClient.connect();
+	}
+
+	shouldCloseConnection() {
+
+		if(process.env.CLOSE_MONGODB_CONNECTIONS !== 'false')
+			return true;
 	}
 
 	closeConnections() {

--- a/tests/mongodb-wrapper.js
+++ b/tests/mongodb-wrapper.js
@@ -33,7 +33,7 @@ describe('MongoWrapper', () => {
 	beforeEach(() => {
 		sinon.stub(RealMongoClient.prototype, 'connect');
 		config.host = `${Date.now()}.localhost`;
-		process.env.CLOSE_MONGODB_CONNECTIONS = 'false';
+		process.env.CLOSE_MONGODB_CONNECTIONS = false;
 	});
 
 	afterEach(() => {

--- a/tests/mongodb-wrapper.js
+++ b/tests/mongodb-wrapper.js
@@ -33,7 +33,7 @@ describe('MongoWrapper', () => {
 	beforeEach(() => {
 		sinon.stub(RealMongoClient.prototype, 'connect');
 		config.host = `${Date.now()}.localhost`;
-		process.env.CLOSE_MONGODB_CONNECTIONS = false;
+		process.env.CLOSE_MONGODB_CONNECTIONS = 'false';
 	});
 
 	afterEach(() => {
@@ -195,7 +195,6 @@ describe('MongoWrapper', () => {
 
 			const mongoWrapper = new MongoWrapper(config);
 			await mongoWrapper.makeQuery(model, callback);
-
 
 			sinon.assert.calledOnceWithExactly(RealMongoClient.prototype.connect);
 

--- a/tests/mongodb-wrapper.js
+++ b/tests/mongodb-wrapper.js
@@ -3,15 +3,15 @@
 const assert = require('assert');
 const sinon = require('sinon');
 
-const { MongoClient: RealMongoClient, ObjectID: RealObjectID } = require('mongodb');
+const { MongoClient: RealMongoClient, ObjectId: RealObjectId } = require('mongodb');
 
 const Events = require('@janiscommerce/events');
 
-const { MongoWrapper, ObjectID } = require('../lib/mongodb-wrapper');
+const { MongoWrapper, ObjectId } = require('../lib/mongodb-wrapper');
 
-describe('ObjectID', () => {
-	it('Should export the Mongo ObjectID', () => {
-		assert.deepStrictEqual(ObjectID, RealObjectID);
+describe('ObjectId', () => {
+	it('Should export the Mongo ObjectId', () => {
+		assert.deepStrictEqual(ObjectId, RealObjectId);
 	});
 });
 

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
 
-const { MongoWrapper, ObjectID } = require('../lib/mongodb-wrapper');
+const { MongoWrapper, ObjectId } = require('../lib/mongodb-wrapper');
 const MongoDBError = require('../lib/mongodb-error');
 const MongoDB = require('../lib/mongodb');
 
@@ -254,7 +254,7 @@ describe('MongoDB', () => {
 		it('Should resolve what the mongodb find-method-chain resolves mapping _id field to id', async () => {
 
 			mockChain(true, [{
-				_id: ObjectID('5df0151dbc1d570011949d86'),
+				_id: ObjectId('5df0151dbc1d570011949d86'),
 				foo: 'bar'
 			}]);
 
@@ -291,7 +291,7 @@ describe('MongoDB', () => {
 					foo: 'bar',
 					baz: 1,
 					id: '5df0151dbc1d570011949d86',
-					otherId: ObjectID('5df0151dbc1d570011949d87')
+					otherId: ObjectId('5df0151dbc1d570011949d87')
 				}
 			});
 
@@ -303,10 +303,10 @@ describe('MongoDB', () => {
 					$eq: 1
 				},
 				_id: {
-					$eq: ObjectID('5df0151dbc1d570011949d86')
+					$eq: ObjectId('5df0151dbc1d570011949d86')
 				},
 				otherId: {
-					$eq: ObjectID('5df0151dbc1d570011949d87')
+					$eq: ObjectId('5df0151dbc1d570011949d87')
 				}
 			}, undefined, 0, 500);
 		});
@@ -327,7 +327,7 @@ describe('MongoDB', () => {
 					{
 						foo: 'bar',
 						id: '5df0151dbc1d570011949d86',
-						otherId: [ObjectID('5df0151dbc1d570011949d87'), '5df0151dbc1d570011949d88']
+						otherId: [ObjectId('5df0151dbc1d570011949d87'), '5df0151dbc1d570011949d88']
 					},
 					{
 						baz: {
@@ -346,10 +346,10 @@ describe('MongoDB', () => {
 							$eq: 'bar'
 						},
 						_id: {
-							$eq: ObjectID('5df0151dbc1d570011949d86')
+							$eq: ObjectId('5df0151dbc1d570011949d86')
 						},
 						otherId: {
-							$in: [ObjectID('5df0151dbc1d570011949d87'), ObjectID('5df0151dbc1d570011949d88')]
+							$in: [ObjectId('5df0151dbc1d570011949d87'), ObjectId('5df0151dbc1d570011949d88')]
 						}
 					},
 					{
@@ -521,7 +521,7 @@ describe('MongoDB', () => {
 				}
 			};
 
-			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectID(id) } });
+			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectId(id) } });
 
 			const collection = stubMongo(true, { findOneAndUpdate });
 
@@ -534,7 +534,7 @@ describe('MongoDB', () => {
 
 			sinon.assert.calledOnceWithExactly(findOneAndUpdate, {
 				_id: {
-					$eq: ObjectID(id)
+					$eq: ObjectId(id)
 				}
 			}, {
 				$set: {
@@ -558,7 +558,7 @@ describe('MongoDB', () => {
 				name: 'Some name'
 			};
 
-			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectID(id) } });
+			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectId(id) } });
 
 			const collection = stubMongo(true, { findOneAndUpdate });
 
@@ -575,11 +575,11 @@ describe('MongoDB', () => {
 
 			sinon.assert.calledOnceWithExactly(findOneAndUpdate, {
 				otherId: {
-					$eq: ObjectID('5df0151dbc1d570011949d87')
+					$eq: ObjectId('5df0151dbc1d570011949d87')
 				}
 			}, {
 				$set: {
-					otherId: ObjectID('5df0151dbc1d570011949d87'),
+					otherId: ObjectId('5df0151dbc1d570011949d87'),
 					name: 'Some name'
 				},
 				$currentDate: { dateModified: true },
@@ -598,7 +598,7 @@ describe('MongoDB', () => {
 						name: 'Some name'
 					};
 
-					const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectID(id) } });
+					const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectId(id) } });
 
 					const collection = stubMongo(true, { findOneAndUpdate });
 
@@ -645,7 +645,7 @@ describe('MongoDB', () => {
 				status: 'active'
 			};
 
-			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectID(id) } });
+			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectId(id) } });
 
 			const collection = stubMongo(true, { findOneAndUpdate });
 
@@ -658,7 +658,7 @@ describe('MongoDB', () => {
 
 			sinon.assert.calledOnceWithExactly(findOneAndUpdate, {
 				_id: {
-					$eq: ObjectID(id)
+					$eq: ObjectId(id)
 				}
 			}, {
 				$set: {
@@ -679,7 +679,7 @@ describe('MongoDB', () => {
 				name: 'Some name'
 			};
 
-			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectID(id) } });
+			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectId(id) } });
 
 			const collection = stubMongo(true, { findOneAndUpdate });
 
@@ -701,7 +701,7 @@ describe('MongoDB', () => {
 				name: 'Some name'
 			};
 
-			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectID(id) } });
+			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectId(id) } });
 
 			const collection = stubMongo(true, { findOneAndUpdate });
 
@@ -726,7 +726,7 @@ describe('MongoDB', () => {
 				dateModified: new Date()
 			};
 
-			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectID(id) } });
+			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectId(id) } });
 
 			const collection = stubMongo(true, { findOneAndUpdate });
 
@@ -739,7 +739,7 @@ describe('MongoDB', () => {
 
 			sinon.assert.calledOnceWithExactly(findOneAndUpdate, {
 				_id: {
-					$eq: ObjectID(id)
+					$eq: ObjectId(id)
 				}
 			}, {
 				$set: {
@@ -769,7 +769,7 @@ describe('MongoDB', () => {
 				quantity: 100
 			};
 
-			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectID(id) } });
+			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectId(id) } });
 
 			const collection = stubMongo(true, { findOneAndUpdate });
 
@@ -782,7 +782,7 @@ describe('MongoDB', () => {
 
 			sinon.assert.calledOnceWithExactly(findOneAndUpdate, {
 				_id: {
-					$eq: ObjectID(id)
+					$eq: ObjectId(id)
 				}
 			}, {
 				$set: {
@@ -795,7 +795,7 @@ describe('MongoDB', () => {
 			}, { upsert: true, returnNewDocument: true });
 		});
 
-		it('Should map the model defined ID fields to ObjectIDs', async () => {
+		it('Should map the model defined ID fields to ObjectIds', async () => {
 
 			const id = '5df0151dbc1d570011949d86';
 
@@ -805,7 +805,7 @@ describe('MongoDB', () => {
 				name: 'Some name'
 			};
 
-			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectID(id) } });
+			const findOneAndUpdate = sinon.stub().resolves({ value: { _id: ObjectId(id) } });
 
 			const collection = stubMongo(true, { findOneAndUpdate });
 
@@ -822,11 +822,11 @@ describe('MongoDB', () => {
 
 			sinon.assert.calledOnceWithExactly(findOneAndUpdate, {
 				_id: {
-					$eq: ObjectID(id)
+					$eq: ObjectId(id)
 				}
 			}, {
 				$set: {
-					otherId: ObjectID('5df0151dbc1d570011949d87'),
+					otherId: ObjectId('5df0151dbc1d570011949d87'),
 					name: 'Some name'
 				},
 				$currentDate: { dateModified: true },
@@ -891,7 +891,7 @@ describe('MongoDB', () => {
 				name: 'Some name'
 			};
 
-			const insertOne = sinon.stub().resolves({ insertedId: ObjectID(id) });
+			const insertOne = sinon.stub().resolves({ insertedId: ObjectId(id) });
 
 			const collection = stubMongo(true, { insertOne });
 
@@ -907,7 +907,7 @@ describe('MongoDB', () => {
 			sinon.assert.calledOnceWithExactly(collection, 'myCollection');
 
 			const expectedItem = {
-				otherId: ObjectID('5df0151dbc1d570011949d87'),
+				otherId: ObjectId('5df0151dbc1d570011949d87'),
 				name: 'Some name',
 				dateCreated: sinon.match.date
 			};
@@ -1004,7 +1004,7 @@ describe('MongoDB', () => {
 			const expectedItem = {
 				$set: {
 					dateModified: sinon.match.date,
-					otherId: ObjectID('5df0151dbc1d570011949d87'),
+					otherId: ObjectId('5df0151dbc1d570011949d87'),
 					name: 'Some name',
 					description: 'The description'
 				},
@@ -1021,7 +1021,7 @@ describe('MongoDB', () => {
 
 			sinon.assert.calledOnceWithExactly(updateMany, {
 				_id: {
-					$eq: ObjectID(id)
+					$eq: ObjectId(id)
 				}
 			}, expectedItem, options);
 		});
@@ -1096,7 +1096,7 @@ describe('MongoDB', () => {
 			};
 
 			const expectedItem = {
-				otherId: ObjectID('5df0151dbc1d570011949d87'),
+				otherId: ObjectId('5df0151dbc1d570011949d87'),
 				name: 'Some name',
 				dateCreated: sinon.match.date
 			};
@@ -1104,7 +1104,7 @@ describe('MongoDB', () => {
 			const insertMany = sinon.stub().resolves({
 				acknowledged: true,
 				insertedCount: 1,
-				insertedIds: { 0: ObjectID('5df0151dbc1d570011949d86') }
+				insertedIds: { 0: ObjectId('5df0151dbc1d570011949d86') }
 			});
 
 			const collection = stubMongo(true, { insertMany });
@@ -1234,12 +1234,12 @@ describe('MongoDB', () => {
 					updateOne: {
 						filter: {
 							_id: {
-								$eq: ObjectID('5df0151dbc1d570011949d86')
+								$eq: ObjectId('5df0151dbc1d570011949d86')
 							}
 						},
 						update: {
 							$set: {
-								otherId: ObjectID('5df0151dbc1d570011949d87'),
+								otherId: ObjectId('5df0151dbc1d570011949d87'),
 								name: 'Some name',
 								status: 'active',
 								quantity: 100
@@ -1254,12 +1254,12 @@ describe('MongoDB', () => {
 					updateOne: {
 						filter: {
 							otherId: {
-								$eq: ObjectID('5df0151dbc1d570011949d88')
+								$eq: ObjectId('5df0151dbc1d570011949d88')
 							}
 						},
 						update: {
 							$set: {
-								otherId: ObjectID('5df0151dbc1d570011949d88'),
+								otherId: ObjectId('5df0151dbc1d570011949d88'),
 								name: 'Some name'
 							},
 							$currentDate: { dateModified: true },
@@ -1348,7 +1348,7 @@ describe('MongoDB', () => {
 
 			const expectedItem = {
 				_id: {
-					$eq: ObjectID(id)
+					$eq: ObjectId(id)
 				}
 			};
 
@@ -1379,7 +1379,7 @@ describe('MongoDB', () => {
 
 			const expectedItem = {
 				otherId: {
-					$eq: ObjectID('5df0151dbc1d570011949d87')
+					$eq: ObjectId('5df0151dbc1d570011949d87')
 				}
 			};
 
@@ -1483,10 +1483,10 @@ describe('MongoDB', () => {
 
 			const expectedFilter = {
 				_id: {
-					$in: [ObjectID(id1), ObjectID(id2)]
+					$in: [ObjectId(id1), ObjectId(id2)]
 				},
 				otherId: {
-					$eq: ObjectID('5df0151dbc1d570011949d88')
+					$eq: ObjectId('5df0151dbc1d570011949d88')
 				},
 				name: {
 					$eq: 'Some name'
@@ -1656,7 +1656,7 @@ describe('MongoDB', () => {
 
 		const response = {
 			value: {
-				_id: ObjectID(id),
+				_id: ObjectId(id),
 				name: 'Fake',
 				quantity: 10,
 				total: 100,
@@ -1717,7 +1717,7 @@ describe('MongoDB', () => {
 
 					sinon.assert.calledOnceWithExactly(findOneAndUpdate, {
 						_id: {
-							$eq: ObjectID(id)
+							$eq: ObjectId(id)
 						}
 					}, {}, {
 						$set: {
@@ -1800,7 +1800,7 @@ describe('MongoDB', () => {
 
 					sinon.assert.calledOnceWithExactly(findOneAndUpdate, {
 						_id: {
-							$eq: ObjectID(id)
+							$eq: ObjectId(id)
 						}
 					}, {}, {
 						$set: {


### PR DESCRIPTION
**Links:**
- [Tarea](https://fizzmod.atlassian.net/browse/JCN-355)
- [Subtarea](https://fizzmod.atlassian.net/browse/JCN-356)

**Requerimiento:**
Sumar la validación de una nueva variable de entorno `CLOSE_MONGODB_CONNECTIONS`

Actualmente siempre se cierran las conexiones al escuchar el evento **janiscommerce.ended**

Comportamiento
Tendremos 3 posibilidades para cubrir

Sí `CLOSE_MONGODB_CONNECTIONS` no existe (situación actual y default), se debe cerrar conexiones :white_check_mark: 

Sí `CLOSE_MONGODB_CONNECTIONS` existe con el valor false, no se debe cerrar conexiones :x:

Sí `CLOSE_MONGODB_CONNECTIONS` existe con cualquier otro valor, se debe cerrar conexiones :white_check_mark:   

**Documentación**
Se debe sumar al README.md la variable de entorno y su comportamiento, para que los devs puedan configurarla o no según sus necesidades.

**Descripción de la solución:**
Se agregó la validación solicitada en `mongodb-wrapper` y respectivo test.
En el readme se agregó la documentación.

**Aclaración:**
No estaba pedido en el ticket, pero el `ObjectID` aparecía como deprecado, y se modificó por `ObjectId` que es el que indican en la documentación para su reemplazo