### PR TITLE
JCN 367 soportar multiples updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Now `update` accepts multiple item data
 ## [2.1.0] - 2022-03-02
 ### Added
 - Added new validation to close connections through `CLOSE_MONGODB_CONNECTIONS` environment variable value.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ await mongo.multiInsert(model, [
 <summary>Updates one or more documents in a collection</summary>
 
 - model: `Model`: A model instance
-- values: `Object`: The values to set in the documents
+- values: `Object` or `Array<Object>`: The values to set in the documents
 - filter: `Object`: Filter criteria to match documents
 - options: `Object`: Optional parameters (such as [arrayFilters](https://docs.mongodb.com/v3.6/release-notes/3.6/#arrayfilters)) of the query [See more](https://docs.mongodb.com/v3.6/reference/method/db.collection.updateMany/#definition)
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -179,7 +179,7 @@ module.exports = class MongoDB {
 	/**
 	 * Updates data into the database
 	 * @param {import('@janiscommerce/model')} model Model instance
-	 * @param {MongoDocument} values values to apply
+	 * @param {MongoDocument|Array<MongoDocument} values values to apply
 	 * @param {import('mongodb').UpdateFilter} filters mongodb filters
 	 * @param {import('mongodb').UpdateOptions} options mongodb options
 	 * @returns {Promise<number>} The amount of documents updated
@@ -191,17 +191,17 @@ module.exports = class MongoDB {
 
 		try {
 
-			const operationGroupedValues = this.groupByWriteOperation(values, {
+			const initialValues = {
 				$set: {
 					dateModified: new Date()
 				}
-			});
+			};
 
-			const updateData = Object.entries(operationGroupedValues)
-				.reduce((acum, [operation, operationValues]) => ({
-					...acum,
-					[operation]: ObjectIdHelper.ensureObjectIdsForWrite(model, operationValues)
-				}), {});
+			const operationGroupedValues = Array.isArray(values) ? [...values, initialValues].map(value => this.groupByWriteOperation(value, {})) :
+				this.groupByWriteOperation(values, initialValues);
+
+			const updateData = Array.isArray(operationGroupedValues) ? operationGroupedValues.map(value => this.getUpdateData(model, value)) :
+				this.getUpdateData(model, operationGroupedValues);
 
 			/** @type {import('mongodb').UpdateResult} */
 			const res = await this.mongo.makeQuery(model, collection => collection
@@ -212,6 +212,21 @@ module.exports = class MongoDB {
 		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
+	}
+
+	/**
+	 *
+	 * @private
+	 * @param {import('@janiscommerce/model')} model Model instance
+	 * @param {object} operationGroupedValues
+	 * @returns {object}
+	 */
+	getUpdateData(model, operationGroupedValues) {
+		return Object.entries(operationGroupedValues)
+			.reduce((acum, [operation, operationValues]) => ({
+				...acum,
+				[operation]: ObjectIdHelper.ensureObjectIdsForWrite(model, operationValues)
+			}), {});
 	}
 
 	/**

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -1025,6 +1025,73 @@ describe('MongoDB', () => {
 				}
 			}, expectedItem, options);
 		});
+
+		it('Should update with multiple data', async () => {
+
+			const id = '5df0151dbc1d570011949d86';
+
+			const item = {
+				otherId: '5df0151dbc1d570011949d87',
+				name: 'Some name',
+				$set: {
+					description: 'The description'
+				},
+				$inc: {
+					quantity: -5
+				},
+				$push: {
+					children: {
+						id: '5df0151dbc1d570011949d88',
+						name: 'Children name'
+					}
+				}
+			};
+
+			const item2 = {
+				age: 10
+			};
+
+			const options = { upsert: true };
+
+			const updateMany = sinon.stub().resolves({ modifiedCount: 1 });
+
+			const collection = stubMongo(true, { updateMany });
+
+			const mongodb = new MongoDB(config);
+
+			const result = await mongodb.update(getModel({
+				otherId: {
+					isID: true
+				}
+			}), [item, item2], { id }, options);
+
+			assert.deepStrictEqual(result, 1);
+
+			sinon.assert.calledOnceWithExactly(collection, 'myCollection');
+
+			const expectedItem = {
+				$set: {
+					otherId: ObjectId('5df0151dbc1d570011949d87'),
+					name: 'Some name',
+					description: 'The description'
+				},
+				$inc: {
+					quantity: -5
+				},
+				$push: {
+					children: {
+						id: '5df0151dbc1d570011949d88',
+						name: 'Children name'
+					}
+				}
+			};
+
+			sinon.assert.calledOnceWithExactly(updateMany, {
+				_id: {
+					$eq: ObjectId(id)
+				}
+			}, [expectedItem, { $set: { age: 10 } }, { $set: { dateModified: sinon.match.date } }], options);
+		});
 	});
 
 	describe('multiInsert()', () => {


### PR DESCRIPTION
**LINK AL TICKET**
[Subtarea](https://fizzmod.atlassian.net/browse/JCN-367)

**DESCRIPCIÓN DEL REQUERIMIENTO**
El package de [Mongodb](https://github.com/janis-commerce/mongodb) necesita que al actualizar pueda aceptar tanto objectos (el uso actual) como un array de objectos.

Este cambió es importante para poder realizar multiples operaciones sobre los registros.

Ejemplo de Query: [Mongo playground](https://mongoplayground.net/p/R_3UHRYv9r7)

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados