### PR TITLE
JCN-374 Agregar soporte aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Now can use `aggregate` function.
 
+### Fixed
+- Now can use `$unset` operator in stages correctly.
 ## [2.2.1] - 2022-04-12
 ### Fixed
 - Fix in `increment()`, internal bad argument `{}`

--- a/README.md
+++ b/README.md
@@ -741,6 +741,37 @@ await mongo.dropDatabase();
 
 </details>
 
+### ***async*** `aggregate(model, stages)`
+
+<details>
+<summary>Execute Aggregation operations to obtain computed results</summary>
+
+- model: `Model`: A model instance used for the query.
+- stages: `[Object]`: An array with the aggregation stages. See [Pipelines Stages - MongoDB documentation](https://www.mongodb.com/docs/manual/aggregation/#std-label-aggregation-pipeline-intro) for more information.
+
+- Resolves `[Object]`: The results of executing the stages. The array may contain one document or multiple documents.
+- Rejects `Error` When something bad occurs
+
+To learn more about aggregation, see [MongoDB documentation](https://www.mongodb.com/docs/manual/aggregation/#std-label-aggregation-pipeline-intro)
+
+**Usage:**
+```js
+await mongo.aggregate(model, [
+	{ $match: { _id: '0000000055f2255a1a8e0c54' } }, // find the document with that id
+	{ $unset: 'category' }, // Removes the category field
+]);
+/* > [
+	{
+		id: '0000000055f2255a1a8e0c54',
+		name: 'Product 1',
+		description: 'Product 1 description'
+	}
+]
+*/
+```
+
+</details>
+
 ## Errors
 
 The errors are informed with a `MongoDBError`.

--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ To learn more about aggregation, see [MongoDB documentation](https://www.mongodb
 **Usage:**
 ```js
 await mongo.aggregate(model, [
-	{ $match: { _id: '0000000055f2255a1a8e0c54' } }, // find the document with that id
+	{ $match: { id: '0000000055f2255a1a8e0c54' } }, // find the document with that id
 	{ $unset: 'category' }, // Removes the category field
 ]);
 /* > [

--- a/lib/helpers/object-id.js
+++ b/lib/helpers/object-id.js
@@ -16,6 +16,9 @@ module.exports = class ObjectIdHelper {
 
 	static ensureObjectIdsForWrite(model, item) {
 
+		if(typeof item !== 'object')
+			return item;
+
 		if(Array.isArray(item))
 			return item.map(i => this.ensureObjectIdsForWriteForObject(model, i));
 

--- a/lib/mongodb-error.js
+++ b/lib/mongodb-error.js
@@ -14,7 +14,8 @@ module.exports = class MongoDBError extends Error {
 			INVALID_DISTINCT_KEY: 7,
 			INVALID_FILTER_TYPE: 8,
 			INVALID_INCREMENT_DATA: 9,
-			INVALID_INDEX: 10
+			INVALID_INDEX: 10,
+			INVALID_STAGES: 11
 		};
 
 	}

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -581,7 +581,7 @@ module.exports = class MongoDB {
 		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if(typeof stages !== 'object' || !Array.isArray(stages))
+		if(!Array.isArray(stages))
 			throw new MongoDBError('Invalid aggregation pipes. It must be an array of objects', MongoDBError.codes.INVALID_STAGES);
 
 		const mongoStages = stages.map(pipe => Object.entries(pipe).reduce((acum, [key, value]) => {

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -570,6 +570,37 @@ module.exports = class MongoDB {
 	}
 
 	/**
+	 * Use aggregates operations on the model collection
+	 * @async
+	 * @param {import('@janiscommerce/model')} model Model instance
+	 * @param {object[]} stages An array with the pipe's stages to execute (in order to be executed)
+	 * @returns {Promise<MongoDocument[]>} Computed results
+	 */
+	async aggregate(model, stages) {
+
+		if(!model)
+			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
+
+		if(typeof stages !== 'object' || !Array.isArray(stages))
+			throw new MongoDBError('Invalid aggregation pipes. It must be an array of objects', MongoDBError.codes.INVALID_STAGES);
+
+		const mongoStages = stages.map(pipe => Object.entries(pipe).reduce((acum, [key, value]) => {
+			acum[key] = ObjectIdHelper.ensureObjectIdsForWrite(model, value);
+			return acum;
+		}, {}));
+
+		try {
+			const res = await this.mongo.makeQuery(model, collection => collection
+				.aggregate(mongoStages).toArray());
+
+			return res.map(item => ObjectIdHelper.mapIdForClient(item));
+
+		} catch(err) {
+			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
+		}
+	}
+
+	/**
 	 * @private
 	 */
 	groupByWriteOperation(values, initialValues) {

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2556,9 +2556,9 @@ describe('MongoDB', () => {
 		});
 
 		const invalidStages = [
-			['$unset', 'only with a string'],
-			[100, 'only with a number'],
-			[{ $unset: 'field' }, 'only with an object'],
+			['$unset', 'only a string'],
+			[100, 'only a number'],
+			[{ $unset: 'field' }, 'only an object'],
 			[null, 'empty values']
 		];
 

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2546,4 +2546,102 @@ describe('MongoDB', () => {
 		});
 	});
 
+	describe('aggregate()', () => {
+
+		it('Should throw if no model is passed', async () => {
+			const mongodb = new MongoDB(config);
+			await assert.rejects(() => mongodb.aggregate(null), {
+				code: MongoDBError.codes.INVALID_MODEL
+			});
+		});
+
+		const invalidStages = [
+			['$unset', 'only with a string'],
+			[100, 'only with a number'],
+			[{ $unset: 'field' }, 'only with an object'],
+			[null, 'empty values']
+		];
+
+		invalidStages.forEach(async ([invalidStage, value]) => {
+
+			it(`Should throw if pipe stages with ${value} are passed`, async () => {
+
+				const mongodb = new MongoDB(config);
+
+				await assert.rejects(() => mongodb.aggregate(getModel(), invalidStage), {
+					code: MongoDBError.codes.INVALID_STAGES
+				});
+			});
+		});
+
+		const itemId = '5df0151dbc1d570011949d87';
+
+		const stages = [
+			{ $match: { id: itemId, referenceId: 'display-id' } },
+			{ $unset: 'category' }
+		];
+
+		it('Should throw if connection to DB fails', async () => {
+
+			const collection = stubMongo(false);
+
+			const mongodb = new MongoDB(config);
+
+			await assert.rejects(() => mongodb.aggregate(getModel(), stages), {
+				message: 'Error getting DB',
+				code: MongoDBError.codes.MONGODB_INTERNAL_ERROR
+			});
+
+			sinon.assert.notCalled(collection);
+		});
+
+		it('Should throw if mongodb aggregate method fails', async () => {
+
+			const toArray = sinon.stub().rejects(new Error('Aggregate internal error'));
+			const aggregate = sinon.stub().returns({ toArray });
+
+			const collection = stubMongo(true, { aggregate, toArray });
+
+			const mongodb = new MongoDB(config);
+
+			await assert.rejects(() => mongodb.aggregate(getModel(), stages), {
+				message: 'Aggregate internal error',
+				code: MongoDBError.codes.MONGODB_INTERNAL_ERROR
+			});
+
+			sinon.assert.calledOnceWithExactly(collection, 'myCollection');
+		});
+
+		it('Should execute every pipe stage', async () => {
+
+			const item = {
+				_id: itemId,
+				name: 'Some name',
+				referenceId: 'display-id'
+			};
+
+			const toArray = sinon.stub().resolves([item]);
+			const aggregate = sinon.stub().returns({ toArray });
+
+			const collection = stubMongo(true, { aggregate, toArray });
+
+			const mongodb = new MongoDB(config);
+			const result = await mongodb.aggregate(getModel(), stages);
+
+			assert.deepStrictEqual(result, [{
+				id: itemId,
+				name: 'Some name',
+				referenceId: 'display-id'
+			}]);
+
+			sinon.assert.calledOnceWithExactly(collection, 'myCollection');
+
+			sinon.assert.calledOnceWithExactly(aggregate, [
+				{ $match: { _id: ObjectId(itemId), referenceId: 'display-id' } },
+				{ $unset: 'category' }
+			]);
+
+			sinon.assert.calledOnce(toArray);
+		});
+	});
 });


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-374

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se necesita agregar el soporte para poder usar [Aggregation](https://www.mongodb.com/docs/manual/aggregation/) de Mongodb a través del método [aggregate](https://www.mongodb.com/docs/manual/reference/method/db.collection.aggregate/).

Para esto el método debe cumplir que
Aceptar un array de pipelines con stages para que la base pueda realizar las operaciones.
* por ejemplo para poder usar $match , $group , etc..
* estos stages deben cumplir con poder transformar los id en _id: ObjectId(...) para que la base lo pueda interpretar correctamente
* se debe poder usar $unset como un stage:  

Devolver un array de documentos de los resultados obtenidos.

Se debe documentar esta nueva funcionalidad.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados (editado) .