### PR TITLE
JCN-377 Corregir en metodo Save la forma de guardar ID de mongo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,8 @@ module.exports = {
 	},
 
 	parserOptions: {
-		sourceType: 'script'
+		sourceType: 'script',
+		ecmaVersion: 2020
 	},
 
 	rules: {
@@ -54,7 +55,7 @@ module.exports = {
 			'anonymous': 'never',
 			'named': 'never',
 			'asyncArrow': 'always'
-	  }],
+		}],
 
 		'arrow-parens': ['error', 'as-needed'],
 		'arrow-body-style': 0,

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -11,10 +11,10 @@ jobs:
 
     - uses: actions/checkout@v1
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: npm install, make test-coverage
       run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - run: npm i
       - run: npm test
 
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - run: npm i
       - run: npm run build-types

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 14.x
       - run: npm i
       - run: npm test
 
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 14.x
           registry-url: https://registry.npmjs.org/
       - run: npm i
       - run: npm run build-types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed error in `save` method, where it takes the id data to save from.
 
 ## [2.2.1] - 2022-04-12
 ### Fixed

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -141,7 +141,7 @@ module.exports = class MongoDB {
 			const res = await this.mongo.makeQuery(model, collection => collection
 				.findOneAndUpdate(filters, operationGroupedValues, { upsert: true, returnNewDocument: true }));
 
-			return !res.value ? res.lastErrorObject && res.lastErrorObject.upserted.toString() : res.value._id.toString();
+			return res.value ? res.value._id.toString() : res.lastErrorObject.upserted.toString();
 
 		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -141,7 +141,7 @@ module.exports = class MongoDB {
 			const res = await this.mongo.makeQuery(model, collection => collection
 				.findOneAndUpdate(filters, operationGroupedValues, { upsert: true, returnNewDocument: true }));
 
-			return res && res.value && res.value._id.toString();
+			return !res.value ? res.lastErrorObject && res.lastErrorObject.upserted.toString() : res.value._id.toString();
 
 		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -141,7 +141,7 @@ module.exports = class MongoDB {
 			const res = await this.mongo.makeQuery(model, collection => collection
 				.findOneAndUpdate(filters, operationGroupedValues, { upsert: true, returnNewDocument: true }));
 
-			return res.value ? res.value._id.toString() : res.lastErrorObject.upserted.toString();
+			return res.value ? res.value._id.toString() : res.lastErrorObject.upserted?.toString();
 
 		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);


### PR DESCRIPTION
**Link al ticket:**
[Ticket](https://fizzmod.atlassian.net/browse/JCN-376) || [Subtarea](https://fizzmod.atlassian.net/browse/JCN-377)

**Requerimiento:**
Qué se espera ?
En el package de [mongodb](https://github.com/janis-commerce/mongodb) existe el método save para guardar o actualizar un registro según corresponda. Se espera que este método devuelva el id del registro que creó o actualizó.

Cuál es el problema ?
El problema esta en que cuando crea un registro nuevo no esta devolviendo el id.

Esto sucede porque el package espera sacar esta id del valor value._id, pero esto solo esta sucediendo cuando actualiza un registro y no cuando se crea.

Ejemplo
Asi devuelve el driver al usar save para crear

```
{
  lastErrorObject: {
    n: 1,
    updatedExisting: false,
    upserted: new ObjectId("62604610bcb561a692c980b6")
  },
  value: null,
  ok: 1
}
```
Asi devuelve el driver al usar save para actualizar

```
{
  lastErrorObject: {
    n: 1,
    updatedExisting: true
  },
  value: {
    _id: new ObjectId("62604610bcb561a692c980b6"),
    email: 'some-mail@fizzmod.com',
    firstname: 'Jane',
    lastname: 'Doe',
    ... resto de las propiedades
  },
  ok: 1
}
```

Acceptance criteria
Qué se necesita ?
Se requiere arreglar este comportamiento para que siempre devuelva el id. 

Para esto vamos buscarlo en

en `value._id `, como esta ahora mismo.

o en `lastErrorObject.upserted`.

Y devolverlo como _string_.