### PR TITLE
JCN-381 arreglar unset update

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -11,10 +11,10 @@ jobs:
 
     - uses: actions/checkout@v1
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: npm install, make test-coverage
       run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14.x
       - run: npm i
       - run: npm test
 
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14.x
           registry-url: https://registry.npmjs.org/
       - run: npm i
       - run: npm run build-types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Bug using `$unset` operator in stages in `update` method
 
 ## [2.3.0] - 2022-04-21
 ### Added

--- a/lib/helpers/object-id.js
+++ b/lib/helpers/object-id.js
@@ -16,7 +16,7 @@ module.exports = class ObjectIdHelper {
 
 	static ensureObjectIdsForWrite(model, item) {
 
-		if(typeof item !== 'object')
+		if(typeof item !== 'object' || (Array.isArray(item) && item.length && typeof item[0] === 'string'))
 			return item;
 
 		if(Array.isArray(item))

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -197,7 +197,7 @@ module.exports = class MongoDB {
 				}
 			};
 
-			const operationGroupedValues = Array.isArray(values) ? [...values, initialValues].map(value => this.groupByWriteOperation(value, {})) :
+			const operationGroupedValues = Array.isArray(values) ? [...values, initialValues].map(value => this.formatPipelineStage(value)) :
 				this.groupByWriteOperation(values, initialValues);
 
 			const updateData = Array.isArray(operationGroupedValues) ? operationGroupedValues.map(value => this.getUpdateData(model, value)) :
@@ -598,6 +598,27 @@ module.exports = class MongoDB {
 		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
+	}
+
+
+	/**
+	 * @private
+	 */
+	formatPipelineStage(pipeline) {
+
+		const everyStage = Object.entries(pipeline);
+
+		if(everyStage.every(([key]) => !key.startsWith('$')))
+			return this.groupByWriteOperation(pipeline, {});
+
+		if(everyStage.length > 1)
+			throw new MongoDBError('Can only be one stage per pipeline', MongoDBError.codes.INVALID_STAGES);
+
+		const [[op, value]] = everyStage;
+
+		return {
+			[op]: value
+		};
 	}
 
 	/**

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -1033,22 +1033,11 @@ describe('MongoDB', () => {
 			const item = {
 				otherId: '5df0151dbc1d570011949d87',
 				name: 'Some name',
-				$set: {
-					description: 'The description'
-				},
-				$inc: {
-					quantity: -5
-				},
-				$push: {
-					children: {
-						id: '5df0151dbc1d570011949d88',
-						name: 'Children name'
-					}
-				}
+				description: 'The description'
 			};
 
 			const item2 = {
-				age: 10
+				$unset: ['children.5df0151dbc1d570011949d88', 'children.5df0151dbc1d570011949d89']
 			};
 
 			const options = { upsert: true };
@@ -1069,15 +1058,33 @@ describe('MongoDB', () => {
 
 			sinon.assert.calledOnceWithExactly(collection, 'myCollection');
 
-			const expectedItem = {
-				$set: {
-					otherId: ObjectId('5df0151dbc1d570011949d87'),
-					name: 'Some name',
-					description: 'The description'
+			const expectedItem = [
+				{
+					$set: {
+						otherId: ObjectId('5df0151dbc1d570011949d87'),
+						name: 'Some name',
+						description: 'The description'
+					}
 				},
-				$inc: {
-					quantity: -5
-				},
+				{ $unset: ['children.5df0151dbc1d570011949d88', 'children.5df0151dbc1d570011949d89'] },
+				{ $set: { dateModified: sinon.match.date } }
+			];
+
+			sinon.assert.calledOnceWithExactly(updateMany, {
+				_id: {
+					$eq: ObjectId(id)
+				}
+			}, expectedItem, options);
+		});
+
+		it('Should throw with multiple data but multiple stage in one pipeline', async () => {
+
+			const id = '5df0151dbc1d570011949d86';
+
+			const item = {
+				otherId: '5df0151dbc1d570011949d87',
+				name: 'Some name',
+				description: 'The description',
 				$push: {
 					children: {
 						id: '5df0151dbc1d570011949d88',
@@ -1086,11 +1093,27 @@ describe('MongoDB', () => {
 				}
 			};
 
-			sinon.assert.calledOnceWithExactly(updateMany, {
-				_id: {
-					$eq: ObjectId(id)
+			const item2 = {
+				$unset: 'children.5df0151dbc1d570011949d88'
+			};
+
+			const options = { upsert: true };
+
+			const updateMany = sinon.stub();
+
+			const collection = stubMongo(true, { updateMany });
+
+			const mongodb = new MongoDB(config);
+
+			await assert.rejects(() => mongodb.update(getModel({
+				otherId: {
+					isID: true
 				}
-			}, [expectedItem, { $set: { age: 10 } }, { $set: { dateModified: sinon.match.date } }], options);
+			}), [item, item2], { id }, options));
+
+
+			sinon.assert.notCalled(collection);
+			sinon.assert.notCalled(updateMany);
 		});
 	});
 


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/

**DESCRIPCIÓN DEL REQUERIMIENTO**
Al utilizar el método update con stages sucede que cuando una de estas stages es $unset.

Lo que sucede es que como aggregation es diferente a no usar stages, se sigue formateando mal y haciendo que las query no funcionen.

> En aggregates este problema no existe

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados