### PR TITLE
Jcn 394 add id struct getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Valid id struct getter
 
-
 ## [2.3.2] - 2022-05-02
 ### Fixed
 - Bug using `$unset` operator in stages in `update` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Valid id struct getter
+
 
 ## [2.3.2] - 2022-05-02
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -772,6 +772,21 @@ await mongo.aggregate(model, [
 
 </details>
 
+### `get idStruct()`
+
+<details>
+<summary>Returns valid id struct function.</summary>
+
+- Returns `Function`: struct function to validate ids.
+- Rejects `Error`: When received id is not of type `objectId`.
+
+**Usage:**
+```js
+await mongo.idStruct('6282c2484f64bffff55bcd7c');
+```
+
+</details>
+
 ## Errors
 
 The errors are informed with a `MongoDBError`.

--- a/README.md
+++ b/README.md
@@ -782,7 +782,7 @@ await mongo.aggregate(model, [
 
 **Usage:**
 ```js
-await mongo.idStruct('6282c2484f64bffff55bcd7c');
+	mongo.idStruct('6282c2484f64bffff55bcd7c');
 ```
 
 </details>

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -645,7 +645,7 @@ module.exports = class MongoDB {
 			}, initialValues);
 	}
 
-	get idStruct(){
-		return struct('objectId')
+	get idStruct() {
+		return struct('objectId');
 	}
 };

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -645,6 +645,10 @@ module.exports = class MongoDB {
 			}, initialValues);
 	}
 
+	/**
+	 * Returns a function to validate mongoDB id type
+	 * @returns {Promise<boolean>} true/false
+	 */
 	get idStruct() {
 		return struct('objectId');
 	}

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -647,7 +647,6 @@ module.exports = class MongoDB {
 
 	/**
 	 * Returns a function to validate mongoDB id type
-	 * @returns {Promise<boolean>} true/false
 	 */
 	get idStruct() {
 		return struct('objectId');

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -12,6 +12,8 @@
  * @property {number} page
  */
 
+const { struct } = require('@janiscommerce/superstruct');
+
 const { inspect } = require('util');
 
 const ConfigValidator = require('./config-validator');
@@ -641,5 +643,9 @@ module.exports = class MongoDB {
 					}
 				};
 			}, initialValues);
+	}
+
+	get idStruct(){
+		return struct('objectId')
 	}
 };

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -647,6 +647,7 @@ module.exports = class MongoDB {
 
 	/**
 	 * Returns a function to validate mongoDB id type
+	 * @returns {Function}
 	 */
 	get idStruct() {
 		return struct('objectId');

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2705,4 +2705,13 @@ describe('MongoDB', () => {
 			sinon.assert.calledOnce(toArray);
 		});
 	});
+
+	describe('idStruct()', () => {
+
+		it('Should return an idStruct function', async () => {
+			const mongodb = new MongoDB(config);
+
+			assert.rejects(() => mongodb.idStruct(('123')));
+		});
+	});
 });

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2710,8 +2710,11 @@ describe('MongoDB', () => {
 
 		it('Should return an idStruct function', async () => {
 			const mongodb = new MongoDB(config);
-
-			assert.rejects(() => mongodb.idStruct(('123')));
+			try {
+				mongodb.idStruct('123');
+			} catch(error) {
+				assert.deepStrictEqual(error.message, 'Expected a value of type `objectId` but received `"123"`.');
+			}
 		});
 	});
 });


### PR DESCRIPTION
[Historia](https://fizzmod.atlassian.net/browse/JCN-393)
[Subtarea](https://fizzmod.atlassian.net/browse/JCN-394)

### Descripción del requerimiento
Se necesita agregar en el package de :leaves: [GitHub - janis-commerce/mongodb](https://github.com/janis-commerce/mongodb) alguna manera de validar el id necesario para este driver, ya que en este caso es particular, y si se quiere filtrar sin ser del tipo de dato correcto la base va a explotar y no es correcto.

Para esto se necesita crear un nuevo getter llamado idStruct, que retorne una función struct para validar objectId (que es el tipo de id que necesita mongodb).

Este nuevo getter va ser usado tanto por [GitHub - janis-commerce/model](https://github.com/janis-commerce/model) como por [GitHub - janis-commerce/api-get: A package to handle JANIS Views Get APIs](https://github.com/janis-commerce/api-get) para validar el tipo de ID antes de llegar a la base.

![image](https://user-images.githubusercontent.com/40437300/169896848-8b902095-161e-4dcd-bde6-a62a5d3d223a.png)
![image](https://user-images.githubusercontent.com/40437300/169897443-434ae588-893c-4544-84eb-0936eab3172f.png)