### PR TITLE
JCN-415-change-getTotals-behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Now `getTotals()` performs a `get()` if it was not called before
 
 ## [2.5.7] - 2022-07-22
 ### Changed

--- a/README.md
+++ b/README.md
@@ -443,7 +443,10 @@ Return example:
 }
 ```
 
-If no query was executed before, it will just return the `total` and `pages` properties with a value of zero.
+If the last query response was empty, it will just return the `total` and `pages` properties with a value of zero.
+
+**Since *UNRELEASED*:**
+- If no query was executed before, it will call a `get(model)` without filters first.
 
 **Usage:**
 ```js

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -384,7 +384,10 @@ module.exports = class MongoDB {
 		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if(!model.totalsParams?.length)
+		if(!model.totalsParams)
+			await this.get(model);
+
+		if(!model.totalsParams.length)
 			return { total: 0, pages: 0 };
 
 		const { length, filters, limit, page } = model.totalsParams;

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -1634,25 +1634,18 @@ describe('MongoDB', () => {
 			});
 		});
 
-		it('Should return without calling mongo if get is not called first', async () => {
+		it('Should call get without params if it was not called before', async () => {
 
 			const mongodb = new MongoDB(config);
 
-			const countDocuments = sinon.stub();
-			const estimatedDocumentCount = sinon.stub();
+			sinon.spy(mongodb, 'get');
 
-			const collection = stubMongo(true, { countDocuments, estimatedDocumentCount });
+			mockChain(true, [], null);
 
-			const result = await mongodb.getTotals(getModel());
+			const model = getModel();
+			await mongodb.getTotals(model);
 
-			assert.deepStrictEqual(result, {
-				total: 0,
-				pages: 0
-			});
-
-			sinon.assert.notCalled(collection);
-			sinon.assert.notCalled(countDocuments);
-			sinon.assert.notCalled(estimatedDocumentCount);
+			sinon.assert.calledOnceWithExactly(mongodb.get, model);
 		});
 
 		it('Should return without calling mongo if last query was empty', async () => {


### PR DESCRIPTION
**Links:**
[Historia](https://fizzmod.atlassian.net/browse/JCN-413) - [Subtarea](https://fizzmod.atlassian.net/browse/JCN-415)

**DESCRIPCIÓN DEL REQUERIMIENTO:**
Se necesita modificar el package :package: de Mongodb :leaves: [GitHub - janis-commerce/mongodb](https://github.com/janis-commerce/mongodb) para:

Modificar el comportamiento del getTotals

Cuando se llama ✅ un get antes, siga funcionando como hasta ahora.

Cuando no se llama ❎ a un get antes,  se busque la cantidad total de documentos en la colección (sin filtros)

Actualizar el README en el apartado de getTotals para señalar que a partir de la nueva versión cambia este comportamiento.

**DESCRIPCIÓN DE LA SOLUCIÓN:**
- Se modificó el comportamiento de la función `getTotals(model)` para que realice un `get(model)` si anteriormente no se llamó a un get.
- Se añadieron tests para probar dicha funcionalidad.
- Se añadieron los cambios al **CHANGELOG.md**.
- Se añadió descripcion del nuevo comportamiento al **README.md**.