### PR TITLE
Add filters to getTotal method

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,12 +460,13 @@ await mongo.get(model, { order: { id: 'desc' } });
 
 </details>
 
-### ***async*** `getTotals(model)`
+### ***async*** `getTotals(model, filter)`
 
 <details>
-<summary>Gets information about the quantity of documents matched by the last call to the `get()` method.</summary>
+<summary>Gets information about the quantity of documents matched by filters if present or the last call to the `get()` method.</summary>
 
 - model: `Model`: A model instance used for the query. **IMPORTANT**: This must be the same instance.
+- filter `Object|Array<Object>`: Sets the criteria to match documents. An object means AND operation between multiple filters. An array mean an OR operation. See examples [above](#filters).
 
 - Resolves `Object`: An object containing the totalizers
 - Rejects `Error` When something bad occurs
@@ -482,6 +483,11 @@ Return example:
 
 If the last query response was empty, it will just return the `total` and `pages` properties with a value of zero.
 
+
+
+**Since *3.2.0*:**
+- Added filter to params. If no filter param is present it will use last query filters. If no query was executed before, it will return the totals of the whole collection without filters.
+
 **Since *2.5.8*:**
 - If no query was executed before, it will return the totals of the whole collection without filters.
 
@@ -490,6 +496,10 @@ If the last query response was empty, it will just return the `total` and `pages
 // getTotals
 result = await mongo.getTotals(model);
 // > { page: 1, limit: 500, pages: 1, total: 4 }
+
+// with filter
+result = await mongo.getTotals(model, { name: 'foo' });
+// > { page: 1, limit: 500, pages: 1, total: 1 }
 ```
 
 </details>

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -430,20 +430,27 @@ module.exports = class MongoDB {
 	 * @param {import('@janiscommerce/model')} model Model instance
 	 * @returns {Promise<GetTotalsResult>} total, page size, pages and page from the results.
 	 */
-	async getTotals(model) {
+	async getTotals(model, filter) {
 
 		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
+
+
+		
 		const {
 			length,
-			filters = {},
+			filters: paramsFilters = {},
 			limit = this.config.limit,
 			page = 0
-		} = model.totalsParams || {};
-
+		} = model.totalsParams || {};1
+		
 		if(length === 0)
 			return { total: 0, pages: 0 };
+
+		const parsedFilters = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filter || {}), model);
+
+		const filters = Object.keys(parsedFilters).length ?  parsedFilters : paramsFilters
 
 		try {
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -435,22 +435,19 @@ module.exports = class MongoDB {
 		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-
-
-		
 		const {
 			length,
 			filters: paramsFilters = {},
 			limit = this.config.limit,
 			page = 0
-		} = model.totalsParams || {};1
-		
+		} = model.totalsParams || {};
+
 		if(length === 0)
 			return { total: 0, pages: 0 };
 
 		const parsedFilters = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filter || {}), model);
 
-		const filters = Object.keys(parsedFilters).length ?  parsedFilters : paramsFilters
+		const filters = Object.keys(parsedFilters).length ? parsedFilters : paramsFilters;
 
 		try {
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -445,7 +445,7 @@ module.exports = class MongoDB {
 		if(length === 0)
 			return { total: 0, pages: 0 };
 
-		const parsedFilters = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filter || {}), model);
+		const parsedFilters = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filter), model);
 
 		const filters = Object.keys(parsedFilters).length ? parsedFilters : paramsFilters;
 

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2193,6 +2193,34 @@ describe('MongoDB', () => {
 
 				sinon.assert.notCalled(estimatedDocumentCount);
 			});
+
+			it('Should return the totals object for queries with filters though params, specific page and custom limit using countDocuments()', async () => {
+
+				const mongodb = new MongoDB(config);
+
+				const estimatedDocumentCount = sinon.stub();
+				const countDocuments = sinon.stub().resolves(4);
+
+				const { collection } = mockChain(true, [{ a: 3 }, { a: 4 }], { countDocuments, estimatedDocumentCount });
+
+				const model = getModel();
+				const result = await mongodb.getTotals(model, { status: 'active' });
+
+				assert.deepStrictEqual(result, {
+					total: 4,
+					pageSize: 500,
+					page: 0,
+					pages: 1
+				});
+
+				// Collection no se llama para el get
+				sinon.assert.calledOnce(collection);
+				sinon.assert.calledOnceWithExactly(countDocuments, {
+					status: { $eq: 'active' }
+				});
+
+				sinon.assert.notCalled(estimatedDocumentCount);
+			});
 		});
 
 		context('When not using filters', () => {


### PR DESCRIPTION
### Link de la historia de usuario
https://janiscommerce.atlassian.net/browse/JCN-442

### Link de la/s sub-tareas
https://janiscommerce.atlassian.net/browse/JCN-445

### Descripción del requerimiento
Se necesita modificar el package de [Mongodb](https://github.com/janis-commerce/mongodb/tree/master) para agregarle al package getTotals que acepte un campo nuevo: filters .

Este nuevo campo va a servir para los casos en los que se quiera obtener los totales de una colección en base a unos filtros, evitando hacer un get con esos filtros antes.

Este campo filters se va a tener que formatear con los helpers del package para que pueda hacer la query correctamente.

En caso que no venga este parametro, debe continuar con el comportamiento habitual
Esto va a servir para que el getTotals sepa calcular los totales segun filtros sin usarse el get con anterioridad

### Descripción de la solución
En  /lib/mongodb.js#L433  modificar el método getTotals. Agregarle filters como parametro. 
Se deberá ajustar la logica para ignorar el filter del model que haya quedado de hacer un get previo si es que este parametro existe

Se debe también parsear los filtros que vengan por parametros como se hace en el método get() en la linea 92

### Como probarlo
Ver https://github.com/janis-commerce/api-list/pull/18