### PR TITLE
Jcn 448 skip automatic date modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ const itemsInserted = await mongo.multiInsert(model, [
 - filter: `Object`: Filter criteria to match documents
 - options: `Object`: Optional parameters (such as [arrayFilters](https://docs.mongodb.com/v3.6/release-notes/3.6/#arrayfilters)) of the query [See more](https://docs.mongodb.com/v3.6/reference/method/db.collection.updateMany/#definition)
 	- `updateOne`: _Boolean_. When receive as **true**, `updateOne()` operation will be used, otherwise `updateMany()` is used.
-	- `skipAutomaticSetDateModified`: _Boolean_. When receive as **true**, the field `dateModified` is not updated automatically.
+	- `skipAutomaticSetModifiedData`: _Boolean_. When receive as **true**, the field `dateModified` is not updated automatically.
 
 - Resolves `Number`: The number of modified documents
 - Rejects `Error` When something bad occurs

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ const itemsInserted = await mongo.multiInsert(model, [
 - filter: `Object`: Filter criteria to match documents
 - options: `Object`: Optional parameters (such as [arrayFilters](https://docs.mongodb.com/v3.6/release-notes/3.6/#arrayfilters)) of the query [See more](https://docs.mongodb.com/v3.6/reference/method/db.collection.updateMany/#definition)
 	- `updateOne`: _Boolean_. When receive as **true**, `updateOne()` operation will be used, otherwise `updateMany()` is used.
+	- `skipAutomaticSetDateModified`: _Boolean_. When receive as **true**, the field `dateModified` is not updated automatically.
 
 - Resolves `Number`: The number of modified documents
 - Rejects `Error` When something bad occurs

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -204,23 +204,28 @@ module.exports = class MongoDB {
 
 		try {
 
-			const initialValues = {
+			options = options || {};
+
+			const { updateOne, skipAutomaticSetDateModified, ...restOfOptions } = options;
+
+			const setDateModified = {
 				$set: {
 					dateModified: new Date()
 				}
 			};
 
+			const operationData = Array.isArray(values) ? [...values] : [values];
+
+			if(!skipAutomaticSetDateModified)
+				operationData.push(setDateModified);
+
 			const operationGroupedValues = Array.isArray(values)
-				? [...values, initialValues].map(value => this.formatPipelineStage(value))
-				: this.groupByWriteOperation(values, initialValues);
+				? operationData.map(value => this.formatPipelineStage(value))
+				: this.groupByWriteOperation(...operationData);
 
 			const updateData = Array.isArray(operationGroupedValues)
 				? operationGroupedValues.map(value => this.getUpdateData(model, value))
 				: this.getUpdateData(model, operationGroupedValues);
-
-			options = options || {};
-
-			const { updateOne, ...restOfOptions } = options;
 
 			filters = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filters || {}), model);
 
@@ -743,7 +748,7 @@ module.exports = class MongoDB {
 	/**
 	 * @private
 	 */
-	groupByWriteOperation(values, initialValues) {
+	groupByWriteOperation(values, initialValues = {}) {
 		return Object.entries(values)
 			.reduce((acum, [key, value]) => {
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -197,27 +197,24 @@ module.exports = class MongoDB {
 	 * @param {import('mongodb').UpdateOptions} options mongodb options
 	 * @returns {Promise<number>} The amount of documents updated
 	 */
-	async update(model, values, filters, options) {
+	async update(model, values, filters, options = {}) {
 
 		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		try {
 
-			options = options || {};
+			const operationData = Array.isArray(values) ? [...values] : [values];
 
 			const { updateOne, skipAutomaticSetModifiedData, ...restOfOptions } = options;
 
-			const setDateModified = {
-				$set: {
-					dateModified: new Date()
-				}
-			};
-
-			const operationData = Array.isArray(values) ? [...values] : [values];
-
-			if(!skipAutomaticSetModifiedData)
-				operationData.push(setDateModified);
+			if(!skipAutomaticSetModifiedData) {
+				operationData.push({
+					$set: {
+						dateModified: new Date()
+					}
+				});
+			}
 
 			const operationGroupedValues = Array.isArray(values)
 				? operationData.map(value => this.formatPipelineStage(value))

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -206,7 +206,7 @@ module.exports = class MongoDB {
 
 			options = options || {};
 
-			const { updateOne, skipAutomaticSetDateModified, ...restOfOptions } = options;
+			const { updateOne, skipAutomaticSetModifiedData, ...restOfOptions } = options;
 
 			const setDateModified = {
 				$set: {
@@ -216,7 +216,7 @@ module.exports = class MongoDB {
 
 			const operationData = Array.isArray(values) ? [...values] : [values];
 
-			if(!skipAutomaticSetDateModified)
+			if(!skipAutomaticSetModifiedData)
 				operationData.push(setDateModified);
 
 			const operationGroupedValues = Array.isArray(values)

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -1358,7 +1358,7 @@ describe('MongoDB', () => {
 				$unset: ['children.5df0151dbc1d570011949d88', 'children.5df0151dbc1d570011949d89']
 			};
 
-			const options = { upsert: true, skipAutomaticSetDateModified: true };
+			const options = { upsert: true, skipAutomaticSetModifiedData: true };
 
 			const updateMany = sinon.stub().resolves({ modifiedCount: 1 });
 
@@ -1478,7 +1478,7 @@ describe('MongoDB', () => {
 				status: 'pending'
 			}, {
 				updateOne: true,
-				skipAutomaticSetDateModified: true
+				skipAutomaticSetModifiedData: true
 			});
 
 			assert.deepStrictEqual(result, 1);

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -1344,6 +1344,56 @@ describe('MongoDB', () => {
 			}, expectedItem, options);
 		});
 
+		it('Should update with multiple data and skip set date modified if the flag is enable', async () => {
+
+			const id = '5df0151dbc1d570011949d86';
+
+			const item = {
+				otherId: '5df0151dbc1d570011949d87',
+				name: 'Some name',
+				description: 'The description'
+			};
+
+			const item2 = {
+				$unset: ['children.5df0151dbc1d570011949d88', 'children.5df0151dbc1d570011949d89']
+			};
+
+			const options = { upsert: true, skipAutomaticSetDateModified: true };
+
+			const updateMany = sinon.stub().resolves({ modifiedCount: 1 });
+
+			const collection = stubMongo(true, { updateMany });
+
+			const mongodb = new MongoDB(config);
+
+			const result = await mongodb.update(getModel({
+				otherId: {
+					isID: true
+				}
+			}), [item, item2], { id }, options);
+
+			assert.deepStrictEqual(result, 1);
+
+			sinon.assert.calledOnceWithExactly(collection, 'myCollection');
+
+			const expectedItem = [
+				{
+					$set: {
+						otherId: ObjectId('5df0151dbc1d570011949d87'),
+						name: 'Some name',
+						description: 'The description'
+					}
+				},
+				{ $unset: ['children.5df0151dbc1d570011949d88', 'children.5df0151dbc1d570011949d89'] }
+			];
+
+			sinon.assert.calledOnceWithExactly(updateMany, {
+				_id: {
+					$eq: ObjectId(id)
+				}
+			}, expectedItem, { upsert: true });
+		});
+
 		it('Should throw with multiple data but multiple stage in one pipeline', async () => {
 
 			const id = '5df0151dbc1d570011949d86';
@@ -1409,6 +1459,37 @@ describe('MongoDB', () => {
 				$set: {
 					status: 'processing',
 					dateModified: sinon.match.date
+				}
+			}, {});
+
+		});
+
+		it('Should use updateOne() method when updateOne option was received and skip set date modified if the flag is enable', async () => {
+
+			const updateOne = sinon.stub().resolves({ modifiedCount: 1 });
+
+			const collection = stubMongo(true, { updateOne });
+
+			const mongodb = new MongoDB(config);
+
+			const result = await mongodb.update(getModel(), {
+				status: 'processing'
+			}, {
+				status: 'pending'
+			}, {
+				updateOne: true,
+				skipAutomaticSetDateModified: true
+			});
+
+			assert.deepStrictEqual(result, 1);
+
+			sinon.assert.calledOnceWithExactly(collection, 'myCollection');
+
+			sinon.assert.calledOnceWithExactly(updateOne, {
+				status: { $eq: 'pending' }
+			}, {
+				$set: {
+					status: 'processing'
 				}
 			}, {});
 


### PR DESCRIPTION
Este ajuste es para poder evitar que siempre se sume `dateModified` al update, al mismo tiempo va de la mano con el package de `model` ya que también suma `dateModified`.

Esta el mismo ejemplo explicado en ambos PRs.

El package ya paso por pruebas y fueron correctas comento el escenario que se uso para probar:
En OMS se hizo una lambda que actualiza dos datos puntuales a varios pedidos al mismo tiempo por medio de un filtro, para este ejemplo pongamos tres pedidos.

Sin la flag ósea funcionamiento normal de siempre podemos darle al update 100 veces que siempre va actualizar los tres pedidos, esto pasa porque en todos los casos lo único que se termina actualizando son los campos automáticos.
Con flag y pedidos previamente actualizados, para este caso el resultado es siempre que la cantidad de documentos afectados es 0, con lo cual pasa a ser correcto y a que no se actualiza nada de forma automática
Con flag y pedidos sin el dato nuevo, para este caso lo que se hizo fue a dos de los tres pedidos borrarles el dato que suma el update y con esto conseguir otro escenario, acá el resultado fue de dos documentos afectados.
Con lo cual el funcionamiento fue el esperado ya que para el que no use la flag sigue todo igual.