### PR TITLE
Jcn-482 sumar metodo multiUpdate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,30 @@ await mongo.multiSave(model, [
 
 </details>
 
+### ***async*** `multiUpdate(model, operations)`
+
+<details>
+<summary>Updates multiple documents in a collection.</summary>
+
+- model: `Model`: A model instance used for the query.
+- operations: `Array<Object>`: Array of objects, each defining a filter and the data to update in the documents that match the filter. Each object represents an individual `updateMany` operation on the database.
+- operations.filter: `Object`: Filters used to select the documents to be updated.
+- operations.data: `Object`: Key-value pairs representing the fields to update and their new values in the documents that match the corresponding filter.
+
+- Resolves `Boolean`: `true` if items can be upserted
+- Rejects `Error` When something bad occurs
+
+**Usage:**
+```js
+await mongo.multiUpdate(model, [
+   { filter: { id: [1,2,3] }, data: { name: 'test 1' } },
+   { filter: { otherId: 4 }, data: { name: 'test 2' } }
+]);
+// > true
+```
+
+</details>
+
 ### ***async*** `remove(model, item)`
 
 <details>

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -502,7 +502,7 @@ module.exports = class MongoDB {
 					}
 				}
 			};
-		}).filter(Boolean);
+		});
 
 		try {
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -478,9 +478,9 @@ module.exports = class MongoDB {
 				updateMany: {
 					filter,
 					update: {
-						$set: dataToUpdate
-					},
-					$currentDate: { dateModified: true }
+						$set: dataToUpdate,
+						$currentDate: { dateModified: true }
+					}
 				}
 			};
 		});

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -365,7 +365,7 @@ module.exports = class MongoDB {
 				.insertMany(mongoItems, { ordered: false }));
 
 			/**
-				  res.insertedIds: {
+				res.insertedIds: {
 					'0': new ObjectId("64074bbbcd9d737d71f0465b"),
 					'1': new ObjectId("64074bbbcd9d737d71f0465c"),
 					'2': new ObjectId("64074bbbcd9d737d71f0465d")

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -472,6 +472,8 @@ module.exports = class MongoDB {
 
 			const { id, dateModified, dateCreated, ...dataToUpdate } = data; // to avoid overriding
 
+			filter = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filter || {}), model);
+
 			return {
 				updateMany: {
 					filter,

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -20,6 +20,19 @@
  * @property {number} page
  */
 
+/**
+ * @typedef {object} UpdateOperation
+ * Describes the parameters for an update operation in database.
+ * This includes both the selection criteria and the new data to apply.
+ *
+ * @property {object} filter - The filter conditions used to select the documents to update.
+ * For example, { age: { $gt: 18 } } selects documents where the age field is greater than 18.
+ *
+ * @property {object} data - The new values for the selected documents properties.
+ * Each key-value pair represents a property to update and the new value to set.
+ * For example, { name: "John", age: 30 } sets the 'name' to "John" and 'age' to 30.
+ */
+
 const { struct } = require('@janiscommerce/superstruct');
 
 const { inspect } = require('util');
@@ -454,9 +467,9 @@ module.exports = class MongoDB {
 	/**
 	 * Multi insert/update items into the database
 	 * @param {import('@janiscommerce/model')} model Model instance
-	 * @param {MongoDocument[]} operations update operations to perform
+	 * @param {UpdateOperation} operations update operations to perform
 	 * @returns {Promise<boolean>} true/false
-	 */
+	*/
 	async multiUpdate(model, operations) {
 
 		if(!model)

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -483,9 +483,15 @@ module.exports = class MongoDB {
 
 		const bulkItems = operations.map(({ filter, data }) => {
 
+			if(!data || !Object.keys(data).length)
+				return;
+
 			const { id, dateModified, dateCreated, ...dataToUpdate } = data; // to avoid overriding
 
 			filter = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filter || {}), model);
+
+			if(!Object.keys(filter).length)
+				throw new MongoDBError('Every operation must have filters to apply', MongoDBError.codes.INVALID_ITEM);
 
 			return {
 				updateMany: {
@@ -496,7 +502,10 @@ module.exports = class MongoDB {
 					}
 				}
 			};
-		});
+		}).filter(Boolean);
+
+		if(!bulkItems.length)
+			return;
 
 		try {
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -484,7 +484,7 @@ module.exports = class MongoDB {
 		const bulkItems = operations.map(({ filter, data }) => {
 
 			if(!data || !Object.keys(data).length)
-				return;
+				throw new MongoDBError('Every operation must have data to update', MongoDBError.codes.INVALID_ITEM);
 
 			const { id, dateModified, dateCreated, ...dataToUpdate } = data; // to avoid overriding
 
@@ -503,9 +503,6 @@ module.exports = class MongoDB {
 				}
 			};
 		}).filter(Boolean);
-
-		if(!bulkItems.length)
-			return;
 
 		try {
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -61,12 +61,12 @@ module.exports = class MongoDB {
 	 */
 	async distinct(model, params = {}) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const { key } = params;
 
-		if (!key || typeof key !== 'string')
+		if(!key || typeof key !== 'string')
 			throw new MongoDBError(`Distinct key must be a string. Received ${inspect(key)}`, MongoDBError.codes.INVALID_DISTINCT_KEY);
 
 		const filters = MongoDBFilters.parseFilters(params.filters, model);
@@ -77,7 +77,7 @@ module.exports = class MongoDB {
 
 			return res;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -90,7 +90,7 @@ module.exports = class MongoDB {
 	 */
 	async get(model, params = {}) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const limit = params.limit || this.config.limit;
@@ -107,10 +107,10 @@ module.exports = class MongoDB {
 				cursor = cursor
 					.find(filters);
 
-				if (sort)
+				if(sort)
 					cursor.sort(sort); // before project(), could need a field to sort()
 
-				if (project)
+				if(project)
 					cursor.project(project);
 
 				cursor
@@ -130,7 +130,7 @@ module.exports = class MongoDB {
 
 			return documents.map(document => ObjectIdHelper.mapIdForClient(document));
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -144,7 +144,7 @@ module.exports = class MongoDB {
 	 */
 	async getPaged(model, params = {}, callback) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const sort = MongoDBSort.parseSortingParams(params.order);
@@ -163,10 +163,10 @@ module.exports = class MongoDB {
 				const cursor = collection
 					.find(filters);
 
-				if (sort)
+				if(sort)
 					cursor.sort(sort); // before project(), could need a field to sort()
 
-				if (project)
+				if(project)
 					cursor.project(project);
 
 				cursor.batchSize(batchSize);
@@ -178,14 +178,14 @@ module.exports = class MongoDB {
 					total++;
 					pageItems.push(ObjectIdHelper.mapIdForClient(item));
 
-					if (pageItems.length === batchSize) {
+					if(pageItems.length === batchSize) {
 						page++;
 						await callback.call(null, pageItems, page, batchSize);
 						pageItems = [];
 					}
 				}
 
-				if (pageItems.length) {
+				if(pageItems.length) {
 					page++;
 					await callback.call(null, pageItems, page, batchSize);
 					pageItems = [];
@@ -198,7 +198,7 @@ module.exports = class MongoDB {
 				pages: page
 			};
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -212,7 +212,7 @@ module.exports = class MongoDB {
 	 */
 	async save(model, item, setOnInsert) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const mongoItem = ObjectIdHelper.ensureObjectIdsForWrite(model, item);
@@ -236,7 +236,7 @@ module.exports = class MongoDB {
 
 			return res.value ? res.value._id.toString() : res.lastErrorObject.upserted?.toString();
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -249,7 +249,7 @@ module.exports = class MongoDB {
 	 */
 	async insert(model, item) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		try {
@@ -264,7 +264,7 @@ module.exports = class MongoDB {
 
 			return res.insertedId.toString();
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -279,7 +279,7 @@ module.exports = class MongoDB {
 	 */
 	async update(model, values, filters, options = {}) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		try {
@@ -288,7 +288,7 @@ module.exports = class MongoDB {
 
 			const { updateOne, skipAutomaticSetModifiedData, ...restOfOptions } = options;
 
-			if (!skipAutomaticSetModifiedData) {
+			if(!skipAutomaticSetModifiedData) {
 				operationData.push({
 					$set: {
 						dateModified: new Date()
@@ -313,7 +313,7 @@ module.exports = class MongoDB {
 
 			return res.modifiedCount;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -342,13 +342,13 @@ module.exports = class MongoDB {
 	 */
 	async multiInsert(model, items, options = {}) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if (!Array.isArray(items))
+		if(!Array.isArray(items))
 			throw new MongoDBError('Items must be an Array', MongoDBError.codes.INVALID_ITEM);
 
-		if (!items.length)
+		if(!items.length)
 			throw new MongoDBError('Items must not be empty', MongoDBError.codes.INVALID_ITEM);
 
 		const mongoItems = items.map(item => ({
@@ -375,9 +375,9 @@ module.exports = class MongoDB {
 			indexesAndIds = Object.entries(res.insertedIds)
 				.map(([index, _id]) => ({ index, _id }));
 
-		} catch (err) {
+		} catch(err) {
 
-			if (err.message.indexOf('E11000 duplicate key error collection') || options.failOnDuplicateErrors)
+			if(err.message.indexOf('E11000 duplicate key error collection') || options.failOnDuplicateErrors)
 				throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 
 			const { insertedIds, writeErrors } = err.result.result;
@@ -411,13 +411,13 @@ module.exports = class MongoDB {
 	 */
 	async multiSave(model, items, setOnInsert) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if (!Array.isArray(items))
+		if(!Array.isArray(items))
 			throw new MongoDBError('Items must be an Array', MongoDBError.codes.INVALID_ITEM);
 
-		if (!items.length)
+		if(!items.length)
 			throw new MongoDBError('Items must not be empty', MongoDBError.codes.INVALID_ITEM);
 
 		const bulkItems = items.map(item => {
@@ -445,7 +445,7 @@ module.exports = class MongoDB {
 
 			return true;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 
@@ -490,7 +490,7 @@ module.exports = class MongoDB {
 
 			return true;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 
@@ -504,7 +504,7 @@ module.exports = class MongoDB {
 	 */
 	async remove(model, item) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const mongoItem = ObjectIdHelper.ensureObjectIdsForWrite(model, item);
@@ -518,7 +518,7 @@ module.exports = class MongoDB {
 
 			return res.deletedCount === 1;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 
@@ -532,7 +532,7 @@ module.exports = class MongoDB {
 	 */
 	async multiRemove(model, filter) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const mongoItem = ObjectIdHelper.ensureObjectIdsForWrite(model, filter);
@@ -546,7 +546,7 @@ module.exports = class MongoDB {
 
 			return res.deletedCount;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 
@@ -559,7 +559,7 @@ module.exports = class MongoDB {
 	 */
 	async getTotals(model, filter) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const {
@@ -569,7 +569,7 @@ module.exports = class MongoDB {
 			page = 0
 		} = model.totalsParams || {};
 
-		if (length === 0)
+		if(length === 0)
 			return { total: 0, pages: 0 };
 
 		const parsedFilters = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filter), model);
@@ -593,9 +593,9 @@ module.exports = class MongoDB {
 
 			let total;
 
-			if (length && page > 0 && length < limit)
+			if(length && page > 0 && length < limit)
 				total = ((page - 1) * limit) + length;
-			else if (Object.keys(filters).length) {
+			else if(Object.keys(filters).length) {
 				total = await this.mongo.makeQuery(model, collection => collection
 					.countDocuments(filters));
 			} else {
@@ -616,7 +616,7 @@ module.exports = class MongoDB {
 
 			return result;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -631,7 +631,7 @@ module.exports = class MongoDB {
 	 */
 	async increment(model, filter, incrementData, setData) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const mongoItem = ObjectIdHelper.ensureObjectIdsForWrite(model, filter);
@@ -652,7 +652,7 @@ module.exports = class MongoDB {
 				}, { upsert: false, returnNewDocument: true })); // 'returnNewDocument: true' return the updated document
 
 			return res.value;
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -664,7 +664,7 @@ module.exports = class MongoDB {
 	 */
 	async getIndexes(model) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		try {
@@ -674,7 +674,7 @@ module.exports = class MongoDB {
 
 			return indexes;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -687,7 +687,7 @@ module.exports = class MongoDB {
 	 */
 	async createIndexes(model, indexes) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		validateIndexes(indexes);
@@ -699,7 +699,7 @@ module.exports = class MongoDB {
 
 			return !!result.length;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -722,10 +722,10 @@ module.exports = class MongoDB {
 	 */
 	async dropIndex(model, indexName) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if (typeof indexName !== 'string')
+		if(typeof indexName !== 'string')
 			throw new MongoDBError('Invalid index name: Should exist and must be a string', MongoDBError.codes.INVALID_INDEX);
 
 		try {
@@ -735,7 +735,7 @@ module.exports = class MongoDB {
 
 			return !!result.ok;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 
@@ -749,10 +749,10 @@ module.exports = class MongoDB {
 	 */
 	async dropIndexes(model, indexNames) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if (!Array.isArray(indexNames))
+		if(!Array.isArray(indexNames))
 			throw new MongoDBError('Invalid indexes names: Should exist and must be an array', MongoDBError.codes.INVALID_INDEX);
 
 		try {
@@ -762,7 +762,7 @@ module.exports = class MongoDB {
 			// Returns true only when all the results are true otherwise returns false
 			return results.every(result => !!result);
 
-		} catch (err) {
+		} catch(err) {
 			throw err;
 		}
 	}
@@ -779,7 +779,7 @@ module.exports = class MongoDB {
 
 			return !!result;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -796,7 +796,7 @@ module.exports = class MongoDB {
 
 			return !!result;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -814,7 +814,7 @@ module.exports = class MongoDB {
 
 			return deletedCount;
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -828,10 +828,10 @@ module.exports = class MongoDB {
 	 */
 	async aggregate(model, stages) {
 
-		if (!model)
+		if(!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if (!Array.isArray(stages))
+		if(!Array.isArray(stages))
 			throw new MongoDBError('Invalid aggregation pipes. It must be an array of objects', MongoDBError.codes.INVALID_STAGES);
 
 		const mongoStages = stages.map(pipe => Object.entries(pipe).reduce((acum, [key, value]) => {
@@ -845,7 +845,7 @@ module.exports = class MongoDB {
 
 			return res.map(item => ObjectIdHelper.mapIdForClient(item));
 
-		} catch (err) {
+		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -858,10 +858,10 @@ module.exports = class MongoDB {
 
 		const everyStage = Object.entries(pipeline);
 
-		if (everyStage.every(([key]) => !key.startsWith('$')))
+		if(everyStage.every(([key]) => !key.startsWith('$')))
 			return this.groupByWriteOperation(pipeline, {});
 
-		if (everyStage.length > 1)
+		if(everyStage.length > 1)
 			throw new MongoDBError('Can only be one stage per pipeline', MongoDBError.codes.INVALID_STAGES);
 
 		const [[op, value]] = everyStage;

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -61,12 +61,12 @@ module.exports = class MongoDB {
 	 */
 	async distinct(model, params = {}) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const { key } = params;
 
-		if(!key || typeof key !== 'string')
+		if (!key || typeof key !== 'string')
 			throw new MongoDBError(`Distinct key must be a string. Received ${inspect(key)}`, MongoDBError.codes.INVALID_DISTINCT_KEY);
 
 		const filters = MongoDBFilters.parseFilters(params.filters, model);
@@ -77,7 +77,7 @@ module.exports = class MongoDB {
 
 			return res;
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -90,7 +90,7 @@ module.exports = class MongoDB {
 	 */
 	async get(model, params = {}) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const limit = params.limit || this.config.limit;
@@ -107,10 +107,10 @@ module.exports = class MongoDB {
 				cursor = cursor
 					.find(filters);
 
-				if(sort)
+				if (sort)
 					cursor.sort(sort); // before project(), could need a field to sort()
 
-				if(project)
+				if (project)
 					cursor.project(project);
 
 				cursor
@@ -130,7 +130,7 @@ module.exports = class MongoDB {
 
 			return documents.map(document => ObjectIdHelper.mapIdForClient(document));
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -144,7 +144,7 @@ module.exports = class MongoDB {
 	 */
 	async getPaged(model, params = {}, callback) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const sort = MongoDBSort.parseSortingParams(params.order);
@@ -163,10 +163,10 @@ module.exports = class MongoDB {
 				const cursor = collection
 					.find(filters);
 
-				if(sort)
+				if (sort)
 					cursor.sort(sort); // before project(), could need a field to sort()
 
-				if(project)
+				if (project)
 					cursor.project(project);
 
 				cursor.batchSize(batchSize);
@@ -178,14 +178,14 @@ module.exports = class MongoDB {
 					total++;
 					pageItems.push(ObjectIdHelper.mapIdForClient(item));
 
-					if(pageItems.length === batchSize) {
+					if (pageItems.length === batchSize) {
 						page++;
 						await callback.call(null, pageItems, page, batchSize);
 						pageItems = [];
 					}
 				}
 
-				if(pageItems.length) {
+				if (pageItems.length) {
 					page++;
 					await callback.call(null, pageItems, page, batchSize);
 					pageItems = [];
@@ -198,7 +198,7 @@ module.exports = class MongoDB {
 				pages: page
 			};
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -212,7 +212,7 @@ module.exports = class MongoDB {
 	 */
 	async save(model, item, setOnInsert) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const mongoItem = ObjectIdHelper.ensureObjectIdsForWrite(model, item);
@@ -236,7 +236,7 @@ module.exports = class MongoDB {
 
 			return res.value ? res.value._id.toString() : res.lastErrorObject.upserted?.toString();
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -249,7 +249,7 @@ module.exports = class MongoDB {
 	 */
 	async insert(model, item) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		try {
@@ -264,7 +264,7 @@ module.exports = class MongoDB {
 
 			return res.insertedId.toString();
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -279,7 +279,7 @@ module.exports = class MongoDB {
 	 */
 	async update(model, values, filters, options = {}) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		try {
@@ -288,7 +288,7 @@ module.exports = class MongoDB {
 
 			const { updateOne, skipAutomaticSetModifiedData, ...restOfOptions } = options;
 
-			if(!skipAutomaticSetModifiedData) {
+			if (!skipAutomaticSetModifiedData) {
 				operationData.push({
 					$set: {
 						dateModified: new Date()
@@ -313,7 +313,7 @@ module.exports = class MongoDB {
 
 			return res.modifiedCount;
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -342,13 +342,13 @@ module.exports = class MongoDB {
 	 */
 	async multiInsert(model, items, options = {}) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if(!Array.isArray(items))
+		if (!Array.isArray(items))
 			throw new MongoDBError('Items must be an Array', MongoDBError.codes.INVALID_ITEM);
 
-		if(!items.length)
+		if (!items.length)
 			throw new MongoDBError('Items must not be empty', MongoDBError.codes.INVALID_ITEM);
 
 		const mongoItems = items.map(item => ({
@@ -365,7 +365,7 @@ module.exports = class MongoDB {
 				.insertMany(mongoItems, { ordered: false }));
 
 			/**
-			 	res.insertedIds: {
+				  res.insertedIds: {
 					'0': new ObjectId("64074bbbcd9d737d71f0465b"),
 					'1': new ObjectId("64074bbbcd9d737d71f0465c"),
 					'2': new ObjectId("64074bbbcd9d737d71f0465d")
@@ -375,9 +375,9 @@ module.exports = class MongoDB {
 			indexesAndIds = Object.entries(res.insertedIds)
 				.map(([index, _id]) => ({ index, _id }));
 
-		} catch(err) {
+		} catch (err) {
 
-			if(err.message.indexOf('E11000 duplicate key error collection') || options.failOnDuplicateErrors)
+			if (err.message.indexOf('E11000 duplicate key error collection') || options.failOnDuplicateErrors)
 				throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 
 			const { insertedIds, writeErrors } = err.result.result;
@@ -411,13 +411,13 @@ module.exports = class MongoDB {
 	 */
 	async multiSave(model, items, setOnInsert) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if(!Array.isArray(items))
+		if (!Array.isArray(items))
 			throw new MongoDBError('Items must be an Array', MongoDBError.codes.INVALID_ITEM);
 
-		if(!items.length)
+		if (!items.length)
 			throw new MongoDBError('Items must not be empty', MongoDBError.codes.INVALID_ITEM);
 
 		const bulkItems = items.map(item => {
@@ -445,7 +445,52 @@ module.exports = class MongoDB {
 
 			return true;
 
-		} catch(err) {
+		} catch (err) {
+			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
+		}
+
+	}
+
+	/**
+	 * Multi insert/update items into the database
+	 * @param {import('@janiscommerce/model')} model Model instance
+	 * @param {MongoDocument[]} operations update operations to perform
+	 * @returns {Promise<boolean>} true/false
+	 */
+	async multiUpdate(model, operations) {
+
+		if(!model)
+			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
+
+		if(!Array.isArray(operations))
+			throw new MongoDBError('Operations must be an Array', MongoDBError.codes.INVALID_ITEM);
+
+		if(!operations.length)
+			throw new MongoDBError('Operations must not be empty', MongoDBError.codes.INVALID_ITEM);
+
+		const bulkItems = operations.map(({ filter, data }) => {
+
+			const { id, dateModified, dateCreated, ...dataToUpdate } = data; // to avoid overriding
+
+			return {
+				updateMany: {
+					filter,
+					update: {
+						$set: dataToUpdate
+					},
+					$currentDate: { dateModified: true }
+				}
+			};
+		});
+
+		try {
+
+			await this.mongo.makeQuery(model, collection => collection
+				.bulkWrite(bulkItems));
+
+			return true;
+
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 
@@ -459,7 +504,7 @@ module.exports = class MongoDB {
 	 */
 	async remove(model, item) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const mongoItem = ObjectIdHelper.ensureObjectIdsForWrite(model, item);
@@ -473,7 +518,7 @@ module.exports = class MongoDB {
 
 			return res.deletedCount === 1;
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 
@@ -487,7 +532,7 @@ module.exports = class MongoDB {
 	 */
 	async multiRemove(model, filter) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const mongoItem = ObjectIdHelper.ensureObjectIdsForWrite(model, filter);
@@ -501,7 +546,7 @@ module.exports = class MongoDB {
 
 			return res.deletedCount;
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 
@@ -514,7 +559,7 @@ module.exports = class MongoDB {
 	 */
 	async getTotals(model, filter) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const {
@@ -524,7 +569,7 @@ module.exports = class MongoDB {
 			page = 0
 		} = model.totalsParams || {};
 
-		if(length === 0)
+		if (length === 0)
 			return { total: 0, pages: 0 };
 
 		const parsedFilters = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filter), model);
@@ -548,9 +593,9 @@ module.exports = class MongoDB {
 
 			let total;
 
-			if(length && page > 0 && length < limit)
+			if (length && page > 0 && length < limit)
 				total = ((page - 1) * limit) + length;
-			else if(Object.keys(filters).length) {
+			else if (Object.keys(filters).length) {
 				total = await this.mongo.makeQuery(model, collection => collection
 					.countDocuments(filters));
 			} else {
@@ -571,7 +616,7 @@ module.exports = class MongoDB {
 
 			return result;
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -586,7 +631,7 @@ module.exports = class MongoDB {
 	 */
 	async increment(model, filter, incrementData, setData) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		const mongoItem = ObjectIdHelper.ensureObjectIdsForWrite(model, filter);
@@ -607,7 +652,7 @@ module.exports = class MongoDB {
 				}, { upsert: false, returnNewDocument: true })); // 'returnNewDocument: true' return the updated document
 
 			return res.value;
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -619,7 +664,7 @@ module.exports = class MongoDB {
 	 */
 	async getIndexes(model) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		try {
@@ -629,7 +674,7 @@ module.exports = class MongoDB {
 
 			return indexes;
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -642,7 +687,7 @@ module.exports = class MongoDB {
 	 */
 	async createIndexes(model, indexes) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
 		validateIndexes(indexes);
@@ -654,7 +699,7 @@ module.exports = class MongoDB {
 
 			return !!result.length;
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -677,10 +722,10 @@ module.exports = class MongoDB {
 	 */
 	async dropIndex(model, indexName) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if(typeof indexName !== 'string')
+		if (typeof indexName !== 'string')
 			throw new MongoDBError('Invalid index name: Should exist and must be a string', MongoDBError.codes.INVALID_INDEX);
 
 		try {
@@ -690,7 +735,7 @@ module.exports = class MongoDB {
 
 			return !!result.ok;
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 
@@ -704,10 +749,10 @@ module.exports = class MongoDB {
 	 */
 	async dropIndexes(model, indexNames) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if(!Array.isArray(indexNames))
+		if (!Array.isArray(indexNames))
 			throw new MongoDBError('Invalid indexes names: Should exist and must be an array', MongoDBError.codes.INVALID_INDEX);
 
 		try {
@@ -717,7 +762,7 @@ module.exports = class MongoDB {
 			// Returns true only when all the results are true otherwise returns false
 			return results.every(result => !!result);
 
-		} catch(err) {
+		} catch (err) {
 			throw err;
 		}
 	}
@@ -734,7 +779,7 @@ module.exports = class MongoDB {
 
 			return !!result;
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -751,7 +796,7 @@ module.exports = class MongoDB {
 
 			return !!result;
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -769,7 +814,7 @@ module.exports = class MongoDB {
 
 			return deletedCount;
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -783,10 +828,10 @@ module.exports = class MongoDB {
 	 */
 	async aggregate(model, stages) {
 
-		if(!model)
+		if (!model)
 			throw new MongoDBError('Invalid or empty model', MongoDBError.codes.INVALID_MODEL);
 
-		if(!Array.isArray(stages))
+		if (!Array.isArray(stages))
 			throw new MongoDBError('Invalid aggregation pipes. It must be an array of objects', MongoDBError.codes.INVALID_STAGES);
 
 		const mongoStages = stages.map(pipe => Object.entries(pipe).reduce((acum, [key, value]) => {
@@ -800,7 +845,7 @@ module.exports = class MongoDB {
 
 			return res.map(item => ObjectIdHelper.mapIdForClient(item));
 
-		} catch(err) {
+		} catch (err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);
 		}
 	}
@@ -813,10 +858,10 @@ module.exports = class MongoDB {
 
 		const everyStage = Object.entries(pipeline);
 
-		if(everyStage.every(([key]) => !key.startsWith('$')))
+		if (everyStage.every(([key]) => !key.startsWith('$')))
 			return this.groupByWriteOperation(pipeline, {});
 
-		if(everyStage.length > 1)
+		if (everyStage.length > 1)
 			throw new MongoDBError('Can only be one stage per pipeline', MongoDBError.codes.INVALID_STAGES);
 
 		const [[op, value]] = everyStage;

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2151,6 +2151,42 @@ describe('MongoDB', () => {
 
 			sinon.assert.calledOnceWithExactly(bulkWrite, expectedItems);
 		});
+
+		it('Should set default filters if none is received', async () => {
+
+			const bulkWrite = sinon.stub().resolves({ result: { ok: 2 } });
+
+			const collection = stubMongo(true, { bulkWrite });
+
+			const mongodb = new MongoDB(config);
+
+			const result = await mongodb.multiUpdate(getModel(), [
+				{ data: item1 }
+			]);
+
+			assert.deepStrictEqual(result, true);
+
+			sinon.assert.calledOnceWithExactly(collection, 'myCollection');
+
+			const expectedItems = [
+				{
+					updateMany: {
+						filter: {},
+						update: {
+							$set: {
+								otherId: '5df0151dbc1d570011949d87',
+								name: 'Some name',
+								status: 'active',
+								quantity: 100
+							},
+							$currentDate: { dateModified: true }
+						}
+					}
+				}
+			];
+
+			sinon.assert.calledOnceWithExactly(bulkWrite, expectedItems);
+		});
 	});
 
 	describe('remove()', () => {

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2093,7 +2093,7 @@ describe('MongoDB', () => {
 			sinon.assert.calledOnceWithExactly(collection, 'myCollection');
 		});
 
-		it('Should add Default modified Values', async () => {
+		it.only('Should add Default modified Values', async () => {
 
 			const item2 = {
 				otherId: '5df0151dbc1d570011949d88',
@@ -2109,7 +2109,7 @@ describe('MongoDB', () => {
 
 			const result = await mongodb.multiUpdate(getModel(), [
 				{ filter: { name: 'itemName' }, data: item1 },
-				{ filter: { name: 'itemName2' }, data: item2 }
+				{ filter: { customField: ['sampleValue', 'sampleValue2'] }, data: item2 }
 			]);
 
 			assert.deepStrictEqual(result, true);
@@ -2120,7 +2120,7 @@ describe('MongoDB', () => {
 				{
 					updateMany: {
 						filter: {
-							name: 'itemName'
+							name: { $eq: 'itemName' }
 						},
 						update: {
 							$set: {
@@ -2136,7 +2136,7 @@ describe('MongoDB', () => {
 				{
 					updateMany: {
 						filter: {
-							name: 'itemName2'
+							customField: { $in: ['sampleValue', 'sampleValue2'] }
 						},
 						update: {
 							$set: {

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2160,9 +2160,9 @@ describe('MongoDB', () => {
 
 			const mongodb = new MongoDB(config);
 
-			await mongodb.multiUpdate(getModel(), [
+			await assert.rejects(mongodb.multiUpdate(getModel(), [
 				{ filter: { name: 'itemName' } }
-			]);
+			]), { message: 'Every operation must have data to update' });
 
 			sinon.assert.notCalled(collection);
 			sinon.assert.notCalled(bulkWrite);

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -10,7 +10,7 @@ const MongoDB = require('../lib/mongodb');
 describe('MongoDB', () => {
 
 	const createUniqueIndex = index => {
-		if (Array.isArray(index)) {
+		if(Array.isArray(index)) {
 			return {
 				name: index.join('_'),
 				key: index.reduce((keys, field) => ({ ...keys, [field]: 1 }), {}),
@@ -38,7 +38,7 @@ describe('MongoDB', () => {
 
 			static get [indexesGetter]() {
 
-				if (indexesGetter === 'indexes')
+				if(indexesGetter === 'indexes')
 					return indexes.map(index => createUniqueIndex(index));
 
 				return indexes;
@@ -60,7 +60,7 @@ describe('MongoDB', () => {
 
 		const collection = sinon.stub().returns(collectionReturnValue);
 
-		if (getDbIsSuccessful)
+		if(getDbIsSuccessful)
 			MongoWrapper.prototype.getDb.resolves({ collection });
 		else
 			MongoWrapper.prototype.getDb.rejects(new Error('Error getting DB'));
@@ -97,14 +97,14 @@ describe('MongoDB', () => {
 
 		sinon.assert.calledOnceWithExactly(stubs.find, filters);
 
-		if (order)
+		if(order)
 			sinon.assert.calledOnceWithExactly(stubs.sort, order);
 
 		sinon.assert.calledOnceWithExactly(stubs.skip, skip);
 
 		sinon.assert.calledOnceWithExactly(stubs.limit, limit);
 
-		if (project)
+		if(project)
 			sinon.assert.calledOnceWithExactly(stubs.project, project);
 
 		sinon.assert.calledOnceWithExactly(stubs.toArray);
@@ -527,7 +527,7 @@ describe('MongoDB', () => {
 					return {
 						async next() {
 
-							if (!itemsToResolve.length)
+							if(!itemsToResolve.length)
 								return { done: true };
 
 							const item = itemsToResolve.shift();
@@ -2042,7 +2042,7 @@ describe('MongoDB', () => {
 			quantity: 100
 		};
 
-		const sampleOperation = { filter: { name: 'itemName' }, data: item1 }
+		const sampleOperation = { filter: { name: 'itemName' }, data: item1 };
 
 		it('Should throw if no model is passed', async () => {
 			const mongodb = new MongoDB(config);
@@ -2067,11 +2067,6 @@ describe('MongoDB', () => {
 
 		it('Should throw if connection to DB fails', async () => {
 
-			const item = {
-				id: '5df0151dbc1d570011949d86',
-				name: 'Some name'
-			};
-
 			const collection = stubMongo(false);
 
 			const mongodb = new MongoDB(config);
@@ -2084,11 +2079,6 @@ describe('MongoDB', () => {
 		});
 
 		it('Should throw if mongodb bulkWrite method fails', async () => {
-
-			const item = {
-				id: '5df0151dbc1d570011949d86',
-				name: 'Some name'
-			};
 
 			const bulkWrite = sinon.stub().rejects(new Error('BulkWrite internal error'));
 
@@ -2118,9 +2108,9 @@ describe('MongoDB', () => {
 			const mongodb = new MongoDB(config);
 
 			const result = await mongodb.multiUpdate(getModel(), [
-					{ filter: { name: 'itemName' }, data: item1 },
-					{ filter: { name: 'itemName2' }, data: item2 }
-				]);
+				{ filter: { name: 'itemName' }, data: item1 },
+				{ filter: { name: 'itemName2' }, data: item2 }
+			]);
 
 			assert.deepStrictEqual(result, true);
 
@@ -2151,7 +2141,7 @@ describe('MongoDB', () => {
 						update: {
 							$set: {
 								otherId: '5df0151dbc1d570011949d88',
-								name: 'Some name',
+								name: 'Some name'
 							}
 						},
 						$currentDate: { dateModified: true }
@@ -3745,7 +3735,7 @@ describe('MongoDB', () => {
 			const mongodb = new MongoDB(config);
 			try {
 				mongodb.idStruct('123');
-			} catch (error) {
+			} catch(error) {
 				assert.deepStrictEqual(error.message, 'Expected a value of type `objectId` but received `"123"`.');
 			}
 		});

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2178,7 +2178,7 @@ describe('MongoDB', () => {
 
 			await assert.rejects(mongodb.multiUpdate(getModel(), [
 				{ data: item1 }
-			]), { message: 'Every operation must have filters to apply'});
+			]), { message: 'Every operation must have filters to apply' });
 
 			sinon.assert.notCalled(collection);
 			sinon.assert.notCalled(bulkWrite);

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2093,7 +2093,7 @@ describe('MongoDB', () => {
 			sinon.assert.calledOnceWithExactly(collection, 'myCollection');
 		});
 
-		it.only('Should add Default modified Values', async () => {
+		it('Should add Default modified Values', async () => {
 
 			const item2 = {
 				otherId: '5df0151dbc1d570011949d88',

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2128,9 +2128,9 @@ describe('MongoDB', () => {
 								name: 'Some name',
 								status: 'active',
 								quantity: 100
-							}
-						},
-						$currentDate: { dateModified: true }
+							},
+							$currentDate: { dateModified: true }
+						}
 					}
 				},
 				{
@@ -2142,9 +2142,9 @@ describe('MongoDB', () => {
 							$set: {
 								otherId: '5df0151dbc1d570011949d88',
 								name: 'Some name'
-							}
-						},
-						$currentDate: { dateModified: true }
+							},
+							$currentDate: { dateModified: true }
+						}
 					}
 				}
 			];


### PR DESCRIPTION
Link de la tarea

Epica: https://janiscommerce.atlassian.net/browse/JCN-481

Subtarea: https://janiscommerce.atlassian.net/browse/JCN-482

### Descripción del requerimiento
Actualmente nuestros paquetes de Mongo y Model no permiten realizar múltiples operaciones de actualización en una misma query a menos que exista un indice único (`multiSave`)

En este caso, en la tarea https://janiscommerce.atlassian.net/browse/JHUB-38   surge la necesidad de actualizar todos los skus de múltiples productos, lo cual hoy solo es posible de la siguiente manera:

- obteniendo todos los registros
- modificandolos desde codigo
- guardando con un multiSave

Esta misma operación podría hacerse con una sola query que contenga algo similar a esto

```
[{
	updateMany: {
		filter: { product: '123' },
		update: {
			$set: {
				brand: product1.brand
			}
		}
	}
},
{
	updateMany: {
		filter: { product: '456' },
		update: {
			$set: {
				brand: product2.brand,
				description: product2.description
			}
		}
	}
}]
```

## Solucion

Para permitir este tipo de operaciones vamos a sumar en https://www.npmjs.com/package/@janiscommerce/mongodb  el nuevo método `multiUpdate` el cual recibirá los parámetros `model` y `operations`. Este ultimo parametro sera el que se ejecutara con un bulkwrite

### Descripción de la solución | Análisis Funcional
- Se agrego el nuevo metodo parseando los filtros para que funcione igual al resto de los llamados
- Se sacan de los updates los valores que pueden generar conflictos innecesarios
- Se sumo fecha de modificacion como default

### ¿Cómo se puede probar?
Dejo pruebas realizadas en local en playground:  https://www.loom.com/share/ea24653ff8bb48899bd385439b92ca21?sid=99b91e30-3ce3-47dd-96c2-2d672f7f420a

### CHANGELOG

```
### Changed
- Add *multiUpdate* method to update multiple documents with different filters and values.
```