### PR TITLE
Jcn-488 Adaptar metodo multiUpdate para que acepte multiples operadores y operaciones con pipeline aggregation 

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -501,25 +501,43 @@ module.exports = class MongoDB {
 		if(!operations.length)
 			throw new MongoDBError('Operations must not be empty', MongoDBError.codes.INVALID_ITEM);
 
-		const bulkItems = operations.map(({ filter, data }) => {
+		const bulkItems = operations.map(({ filter, data, options }) => {
 
 			if(!data || !Object.keys(data).length)
 				throw new MongoDBError('Every operation must have data to update', MongoDBError.codes.INVALID_ITEM);
 
-			const { id, dateModified, dateCreated, ...dataToUpdate } = data; // to avoid overriding
+			const operationData = Array.isArray(data) ? [...data] : [data];
+
+			const { updateOne, skipAutomaticSetModifiedData, ...restOfOptions } = options || {};
+
+			if(!skipAutomaticSetModifiedData) {
+				operationData.push({
+					$set: {
+						dateModified: new Date()
+					}
+				});
+			}
+
+			const updateMethod = updateOne ? 'updateOne' : 'updateMany';
 
 			filter = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filter || {}), model);
 
 			if(!Object.keys(filter).length)
 				throw new MongoDBError('Every operation must have filters to apply', MongoDBError.codes.INVALID_ITEM);
 
+			const operationGroupedData = Array.isArray(data)
+				? operationData.map(value => this.formatPipelineStage(value))
+				: this.groupByWriteOperation(...operationData);
+
+			const updateData = Array.isArray(operationGroupedData)
+				? operationGroupedData.map(value => this.getUpdateData(model, value))
+				: this.getUpdateData(model, operationGroupedData);
+
 			return {
-				updateMany: {
+				[updateMethod]: {
 					filter,
-					update: {
-						$set: dataToUpdate,
-						$currentDate: { dateModified: true }
-					}
+					update: updateData,
+					...restOfOptions
 				}
 			};
 		});

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -300,7 +300,7 @@ module.exports = class MongoDB {
 	 * @param {Array|Object} values - Values to update.
 	 * @param {Object} [options={}] - Extra parameters to format the query.
 	 * @param {object|array<object>} filters Filters to apply to the query
-	 * @returns The formatted update data, method, filters, and extra parameters.
+	 * @returns The formatted update data, method, formatted filters, and extra parameters.
 	 */
 	formatDataToUpdate(model, values, options = {}, filters) {
 
@@ -326,12 +326,12 @@ module.exports = class MongoDB {
 
 		const updateMethod = updateOne ? 'updateOne' : 'updateMany';
 
-		filters = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filters || {}), model);
+		const formattedFilters = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filters || {}), model);
 
 		return {
 			updateData,
 			updateMethod,
-			filters,
+			formattedFilters,
 			...extraParams
 		};
 	}
@@ -354,7 +354,7 @@ module.exports = class MongoDB {
 			const {
 				updateData,
 				updateMethod,
-				filters: formattedFilters,
+				formattedFilters,
 				...extraParams
 			} = this.formatDataToUpdate(model, values, options, filters);
 
@@ -534,7 +534,7 @@ module.exports = class MongoDB {
 			const {
 				updateData,
 				updateMethod,
-				filters: formattedFilters,
+				formattedFilters,
 				...extraParams
 			} = this.formatDataToUpdate(model, data, options, filter);
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -295,6 +295,49 @@ module.exports = class MongoDB {
 	}
 
 	/**
+	 * 
+	 * @param {*} model 
+	 * @param {*} values 
+	 * @param {*} options 
+	 * @param {*} filters 
+	 * @returns 
+	 */
+	formatDataToUpdate(model, values, options = {}, filters){
+
+		const operationData = Array.isArray(values) ? [...values] : [values];
+
+		const { updateOne, skipAutomaticSetModifiedData, ...extraParams } = options;
+
+		if (!skipAutomaticSetModifiedData) {
+			operationData.push({
+				$set: {
+					dateModified: new Date()
+				}
+			});
+		}
+
+		const operationGroupedValues = Array.isArray(values)
+			? operationData.map(value => this.formatPipelineStage(value))
+			: this.groupByWriteOperation(...operationData);
+
+		const updateData = Array.isArray(operationGroupedValues)
+			? operationGroupedValues.map(value => this.getUpdateData(model, value))
+			: this.getUpdateData(model, operationGroupedValues);
+
+		const updateMethod = updateOne ? 'updateOne' : 'updateMany';
+
+		filters = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filters || {}), model);
+
+		return {
+			updateData,
+			updateMethod,
+			filters,
+			...extraParams
+		}
+
+	}
+
+	/**
 	 * Updates data into the database
 	 * @param {import('@janiscommerce/model')} model Model instance
 	 * @param {MongoDocument|Array<MongoDocument} values values to apply
@@ -309,34 +352,17 @@ module.exports = class MongoDB {
 
 		try {
 
-			const operationData = Array.isArray(values) ? [...values] : [values];
-
-			const { updateOne, skipAutomaticSetModifiedData, ...restOfOptions } = options;
-
-			if(!skipAutomaticSetModifiedData) {
-				operationData.push({
-					$set: {
-						dateModified: new Date()
-					}
-				});
-			}
-
-			const operationGroupedValues = Array.isArray(values)
-				? operationData.map(value => this.formatPipelineStage(value))
-				: this.groupByWriteOperation(...operationData);
-
-			const updateData = Array.isArray(operationGroupedValues)
-				? operationGroupedValues.map(value => this.getUpdateData(model, value))
-				: this.getUpdateData(model, operationGroupedValues);
-
-			filters = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filters || {}), model);
-
-			const updateMethod = updateOne ? 'updateOne' : 'updateMany';
+			const { 
+				updateData,
+				updateMethod,
+				filters: formattedFilters,
+				...extraParams
+			} = this.formatDataToUpdate(model, values, options, filters) 
 
 			/** @type {import('mongodb').UpdateResult} */
-			const res = await this.mongo.makeQuery(model, collection => collection[updateMethod](filters, updateData, {
+			const res = await this.mongo.makeQuery(model, collection => collection[updateMethod](formattedFilters, updateData, {
 				...process.env.AWS_LAMBDA_FUNCTION_NAME && { comment: process.env.AWS_LAMBDA_FUNCTION_NAME },
-				...restOfOptions
+				...extraParams
 			}));
 
 			return res.modifiedCount;
@@ -506,38 +532,21 @@ module.exports = class MongoDB {
 			if(!data || !Object.keys(data).length)
 				throw new MongoDBError('Every operation must have data to update', MongoDBError.codes.INVALID_ITEM);
 
-			const operationData = Array.isArray(data) ? [...data] : [data];
+			const {
+				updateData,
+				updateMethod,
+				filters: formattedFilters,
+				...extraParams
+			} = this.formatDataToUpdate(model, data, options, filter)
 
-			const { updateOne, skipAutomaticSetModifiedData, ...restOfOptions } = options || {};
-
-			if(!skipAutomaticSetModifiedData) {
-				operationData.push({
-					$set: {
-						dateModified: new Date()
-					}
-				});
-			}
-
-			const updateMethod = updateOne ? 'updateOne' : 'updateMany';
-
-			filter = MongoDBFilters.parseFilters(ObjectIdHelper.ensureObjectIdsForWrite(model, filter || {}), model);
-
-			if(!Object.keys(filter).length)
+			if(!Object.keys(formattedFilters).length)
 				throw new MongoDBError('Every operation must have filters to apply', MongoDBError.codes.INVALID_ITEM);
-
-			const operationGroupedData = Array.isArray(data)
-				? operationData.map(value => this.formatPipelineStage(value))
-				: this.groupByWriteOperation(...operationData);
-
-			const updateData = Array.isArray(operationGroupedData)
-				? operationGroupedData.map(value => this.getUpdateData(model, value))
-				: this.getUpdateData(model, operationGroupedData);
 
 			return {
 				[updateMethod]: {
-					filter,
+					filter: formattedFilters,
 					update: updateData,
-					...restOfOptions
+					...extraParams
 				}
 			};
 		});

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -295,20 +295,20 @@ module.exports = class MongoDB {
 	}
 
 	/**
-	 * 
-	 * @param {*} model 
-	 * @param {*} values 
-	 * @param {*} options 
-	 * @param {*} filters 
-	 * @returns 
+	 * Formats records to update
+	 * @param {Model} model - The model to apply the query to.
+	 * @param {Array|Object} values - Values to update.
+	 * @param {Object} [options={}] - Extra parameters to format the query.
+	 * @param {object|array<object>} filters Filters to apply to the query
+	 * @returns The formatted update data, method, filters, and extra parameters.
 	 */
-	formatDataToUpdate(model, values, options = {}, filters){
+	formatDataToUpdate(model, values, options = {}, filters) {
 
 		const operationData = Array.isArray(values) ? [...values] : [values];
 
 		const { updateOne, skipAutomaticSetModifiedData, ...extraParams } = options;
 
-		if (!skipAutomaticSetModifiedData) {
+		if(!skipAutomaticSetModifiedData) {
 			operationData.push({
 				$set: {
 					dateModified: new Date()
@@ -333,8 +333,7 @@ module.exports = class MongoDB {
 			updateMethod,
 			filters,
 			...extraParams
-		}
-
+		};
 	}
 
 	/**
@@ -352,12 +351,12 @@ module.exports = class MongoDB {
 
 		try {
 
-			const { 
+			const {
 				updateData,
 				updateMethod,
 				filters: formattedFilters,
 				...extraParams
-			} = this.formatDataToUpdate(model, values, options, filters) 
+			} = this.formatDataToUpdate(model, values, options, filters);
 
 			/** @type {import('mongodb').UpdateResult} */
 			const res = await this.mongo.makeQuery(model, collection => collection[updateMethod](formattedFilters, updateData, {
@@ -537,7 +536,7 @@ module.exports = class MongoDB {
 				updateMethod,
 				filters: formattedFilters,
 				...extraParams
-			} = this.formatDataToUpdate(model, data, options, filter)
+			} = this.formatDataToUpdate(model, data, options, filter);
 
 			if(!Object.keys(formattedFilters).length)
 				throw new MongoDBError('Every operation must have filters to apply', MongoDBError.codes.INVALID_ITEM);

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -2423,7 +2423,7 @@ describe('MongoDB', () => {
 					}
 				}
 			];
-			
+
 			sinon.assert.calledOnceWithExactly(bulkWrite, expectedItems, { comment });
 		});
 


### PR DESCRIPTION
[historia](https://janiscommerce.atlassian.net/browse/JCN-486)

[subtarea](https://janiscommerce.atlassian.net/browse/JCN-488)

## Descripcion del requerimiento:

Se requiere modificar el metodo multiUpdate para que acepte pipelines y multiples operadores (hoy automaticamente asigna lo recibido a un $set) dentro de los valores a actualizar en cada operacion.

## Como probar
Dejo pruebas en playground
[Funcionamiento con pipelines](https://www.loom.com/share/66beffbe73e3421d99610422dc9971fa)
[Funcionamiento con updates normales (funcionamiento vigente y que debe continuar)](https://www.loom.com/share/21e83c18531245258145af4059a1f96a)

## Changelog:
```
## Changed
- MultiUpdate method now accepts all available update operators and operations with pipeline aggregations
```