### PR TITLE
Get param type cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ await mongo.distinct(model, { key: 'color', filters: { status: 'active' } });
 - model: `Model`: A model instance
 - parameters: `Object` (optional): The query parameters. Default: `{}`
 
-- Resolves `Array<Object>|Cursor`: An array of documents (default) or MongoDB cursor when `type: 'cursor'` is specified
+- Resolves `Array<Object>|Cursor`: An array of documents (default) or MongoDB cursor when `returnType: 'cursor'` is specified
 - Rejects `Error` When something bad occurs
 
 **Available parameters: (all of them are optional)**
@@ -234,7 +234,7 @@ await mongo.distinct(model, { key: 'color', filters: { status: 'active' } });
 - filters `Object|Array<Object>`: Sets the criteria to match documents. An object means AND operation between multiple filters. An array mean an OR operation. See examples [below](#filters).
 - fields `Array<String>`: **Since 2.7.0**. Specific fields to be returned in the query for every document. This feature uses MongoDB projections. See more: https://www.mongodb.com/docs/manual/tutorial/project-fields-from-query-results/
 - excludeFields `Array<String>`: **Since 2.7.0**. Specific fields to exclude in the query for every document. Available when `fields` was not received. This feature also uses MongoDB projections.
-- type `String`: When set to `'cursor'`, returns the MongoDB cursor directly instead of converting it to an array. This allows for advanced cursor operations and streaming of large datasets.
+- returnType `String`: When set to `'cursor'`, returns the MongoDB cursor directly instead of converting it to an array. This allows for advanced cursor operations and streaming of large datasets.
 
 Parameters example:
 ```js
@@ -252,7 +252,7 @@ Parameters example:
       }
    },
 	fields: ['itemField', 'otherItemField'],
-	type: 'cursor' // Returns MongoDB cursor directly
+	returnType: 'cursor' // Returns MongoDB cursor directly
 }
 ```
 
@@ -466,7 +466,7 @@ await mongo.get(model, { order: { id: 'desc' } });
 // > [ ... ] // Every document in the collection, ordered by descending id, up to 500 documents.
 
 // returning MongoDB cursor directly for advanced operations
-const cursor = await mongo.get(model, { type: 'cursor' });
+const cursor = await mongo.get(model, { returnType: 'cursor' });
 // > MongoDB Cursor object // Allows for streaming, custom iteration, etc.
 ```
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ await mongo.distinct(model, { key: 'color', filters: { status: 'active' } });
 - model: `Model`: A model instance
 - parameters: `Object` (optional): The query parameters. Default: `{}`
 
-- Resolves `Array<Object>`: An array of documents
+- Resolves `Array<Object>|Cursor`: An array of documents (default) or MongoDB cursor when `type: 'cursor'` is specified
 - Rejects `Error` When something bad occurs
 
 **Available parameters: (all of them are optional)**
@@ -234,6 +234,7 @@ await mongo.distinct(model, { key: 'color', filters: { status: 'active' } });
 - filters `Object|Array<Object>`: Sets the criteria to match documents. An object means AND operation between multiple filters. An array mean an OR operation. See examples [below](#filters).
 - fields `Array<String>`: **Since 2.7.0**. Specific fields to be returned in the query for every document. This feature uses MongoDB projections. See more: https://www.mongodb.com/docs/manual/tutorial/project-fields-from-query-results/
 - excludeFields `Array<String>`: **Since 2.7.0**. Specific fields to exclude in the query for every document. Available when `fields` was not received. This feature also uses MongoDB projections.
+- type `String`: When set to `'cursor'`, returns the MongoDB cursor directly instead of converting it to an array. This allows for advanced cursor operations and streaming of large datasets.
 
 Parameters example:
 ```js
@@ -250,7 +251,8 @@ Parameters example:
          'type' : 'in'
       }
    },
-	fields: ['itemField', 'otherItemField']
+	fields: ['itemField', 'otherItemField'],
+	type: 'cursor' // Returns MongoDB cursor directly
 }
 ```
 
@@ -462,6 +464,10 @@ await mongo.get(model, { limit: 10, page: 2 filters: { name: 'foo' } })
 // finding all entries ordered descendently by id
 await mongo.get(model, { order: { id: 'desc' } });
 // > [ ... ] // Every document in the collection, ordered by descending id, up to 500 documents.
+
+// returning MongoDB cursor directly for advanced operations
+const cursor = await mongo.get(model, { type: 'cursor' });
+// > MongoDB Cursor object // Allows for streaming, custom iteration, etc.
 ```
 
 </details>

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -56,6 +56,10 @@ const MongoDBProject = require('./helpers/project');
 const IncrementValidator = require('./helpers/increment-validator');
 const prepareDateCreated = require('./helpers/prepare-date-created');
 
+const RETURN_TYPE = {
+	CURSOR: 'cursor'
+};
+
 /**
  * @class MongoDB
  * @classdesc MongoDB driver module
@@ -127,7 +131,7 @@ module.exports = class MongoDB {
 			if(process.env.MONGODB_DEBUG)
 				logger.info(`get() ${model.constructor.table} - filters ${JSON.stringify(filters)} - sort ${JSON.stringify(sort)}`);
 
-			const documents = await this.mongo.makeQuery(model, cursor => {
+			const result = await this.mongo.makeQuery(model, cursor => {
 
 				cursor = cursor
 					.find(filters, {
@@ -144,18 +148,24 @@ module.exports = class MongoDB {
 					.skip((limit * page) - limit)
 					.limit(limit);
 
+				if(params.type === RETURN_TYPE.CURSOR)
+					return cursor;
+
 				return cursor.toArray();
 			});
 
+			if(params.type === RETURN_TYPE.CURSOR)
+				return result;
+
 			model.totalsParams = {
-				length: documents.length,
+				length: result.length,
 				limit,
 				page,
 				filters,
 				order: sort
 			};
 
-			return documents.map(document => ObjectIdHelper.mapIdForClient(document));
+			return result.map(document => ObjectIdHelper.mapIdForClient(document));
 
 		} catch(err) {
 			throw new MongoDBError(err, MongoDBError.codes.MONGODB_INTERNAL_ERROR);

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -144,12 +144,12 @@ module.exports = class MongoDB {
 				if(project)
 					cursor.project(project);
 
+				if(params.type === RETURN_TYPE.CURSOR)
+					return cursor;
+
 				cursor
 					.skip((limit * page) - limit)
 					.limit(limit);
-
-				if(params.type === RETURN_TYPE.CURSOR)
-					return cursor;
 
 				return cursor.toArray();
 			});

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -144,7 +144,7 @@ module.exports = class MongoDB {
 				if(project)
 					cursor.project(project);
 
-				if(params.type === RETURN_TYPE.CURSOR)
+				if(params.returnType === RETURN_TYPE.CURSOR)
 					return cursor;
 
 				cursor
@@ -154,7 +154,7 @@ module.exports = class MongoDB {
 				return cursor.toArray();
 			});
 
-			if(params.type === RETURN_TYPE.CURSOR)
+			if(params.returnType === RETURN_TYPE.CURSOR)
 				return result;
 
 			model.totalsParams = {

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -485,6 +485,18 @@ describe('MongoDB', () => {
 			assertChain(stubs, 'myCollection', {}, undefined, 60, 30);
 		});
 
+		it('Should return the cursor when type is cursor', async () => {
+
+			const stubs = mockChain(true);
+
+			const mongodb = new MongoDB(config);
+			const result = await mongodb.get(getModel(), {
+				type: 'cursor'
+			});
+
+			assert.strictEqual(result, stubs.find.returnValues[0]);
+		});
+
 		describe('projection', () => {
 
 			it('Should pass the project param to select fields to the find-method-chain when received fields', async () => {

--- a/tests/mongodb.js
+++ b/tests/mongodb.js
@@ -485,13 +485,13 @@ describe('MongoDB', () => {
 			assertChain(stubs, 'myCollection', {}, undefined, 60, 30);
 		});
 
-		it('Should return the cursor when type is cursor', async () => {
+		it('Should return the cursor when return type is cursor', async () => {
 
 			const stubs = mockChain(true);
 
 			const mongodb = new MongoDB(config);
 			const result = await mongodb.get(getModel(), {
-				type: 'cursor'
+				returnType: 'cursor'
 			});
 
 			assert.strictEqual(result, stubs.find.returnValues[0]);


### PR DESCRIPTION
Se agrego al get que permita devolver el cursor directo para poder operar por ejemplo por stream sin depender de los pasos del 📦 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional cursor return from data queries: request a MongoDB Cursor (via returnType: 'cursor') instead of an array for streaming and advanced operations. Default array behavior unchanged.
- Documentation
  - README updated with returnType examples and cursor usage for get() and distinct().
- Tests
  - Added tests confirming get() can return a Cursor when requested and preserves existing behavior otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->